### PR TITLE
feat(hsms): fan-out-safe clones (CloneCodec, SnapshotForRelay) + secs2 deep-clone race fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Adds `DataMessage.CloneCodec` and fixes a data race in `secs2.ListItem.Clone`
+exposed on the concurrent fan-out (multi-handler / broadcast) path, closing the
+related `ASCIIItem` aliasing hazard.
+
+### Added
+
+- **`hsms`: `DataMessage.CloneCodec`** — returns an independent deep copy of the
+  message typed only as the `encoding.BinaryMarshaler`/`BinaryUnmarshaler` pair.
+  This lets external code obtain a fan-out-safe deep copy through a capability
+  interface it declares itself, without importing this package or depending on
+  the concrete `*DataMessage` type. Thin wrapper over `Clone`.
+- **`hsms`: `DataMessage.SnapshotForRelay`** — opt-in, relay-optimized snapshot
+  that serializes the message once and serves those bytes from `ToBytes` without
+  re-encoding, decoding the item structure lazily only if a structural method
+  (e.g. `Item`, `ToDataMessage`) is called on the result. For the
+  serialize-and-forward (relay / broadcast / shadow) path it is markedly cheaper
+  than `Clone` (measured ~4.6× faster for a single large-leaf payload; ~110–200×
+  faster for multi-item / nested lists; 2–5 allocations vs 12–2024). It is a
+  trade-off, not a free win: if the consumer accesses items, `SnapshotForRelay`
+  is *slower* than `Clone` (serialize-at-clone plus lazy-decode-at-access), so
+  `Clone` remains the right choice for structural consumers (including the
+  in-process handler fan-out path). `Clone`/`CloneCodec` are unchanged
+  (structural deep copy). `Item()` on the returned message yields a
+  lazily-decoded item — use the `secs2.Item` interface, not concrete-type
+  assertions, to remain compatible with future implementations.
+
+### Fixed
+
+- **`hsms`: decode JIS8 and localized-string items.** `DecodeSECS2Item` /
+  `DecodeHSMSMessage` previously returned "invalid format" for JIS8 (0o21) and
+  localized-string (0o22) payloads; both are now decoded correctly.
+- **`secs2`: `ListItem.Clone` now performs a recursive deep copy.** Previously it
+  shared child items with the original, which caused a data race when a cloned
+  message and its source were serialized concurrently (the fan-out / multi-handler
+  path). Clones are now fully independent.
+- **`secs2`: `ASCIIItem.SetValues` no longer retains a caller-supplied `[]byte`
+  (it now copies the input).** Combined with the deep `ListItem.Clone`, ASCII
+  leaves can safely share their now-owned/immutable backing, so common payloads
+  (including large ASCII recipes built from strings) still clone without copying
+  the data.
+- **`secs2`: `SetValues` now invalidates the cached serialization.** Calling
+  `SetValues` on an item that had already been serialized via `ToBytes` left the
+  stale `rawBytes` cache in place, so the next `ToBytes` returned the previous
+  value's bytes. Affects `ASCIIItem`, `BinaryItem`, `BooleanItem`, and `ListItem`.
+
 ## [1.17.1] - 2026-06-03
 
 Patch follow-up to v1.17.0 that makes the `DataMsgDropNotSelectedCount`

--- a/hsms/clone_bench_test.go
+++ b/hsms/clone_bench_test.go
@@ -1,0 +1,83 @@
+package hsms
+
+import (
+	"testing"
+
+	"github.com/arloliu/go-secs/secs2"
+)
+
+// The Clone vs CloneCodec benchmarks quantify the overhead of the CloneCodec
+// wrapper relative to the underlying Clone. CloneCodec is a thin wrapper that
+// only differs by an interface-to-interface conversion of the result, so any
+// gap between the two pairs is purely that conversion (Clone itself dominates
+// the cost via the deep secs2.Item copy).
+
+// cloneBenchItems returns representative payloads spanning the realistic range:
+// a small ASCII reply, a moderately nested list, and a large recipe blob.
+func cloneBenchPayloads() []struct {
+	name string
+	item secs2.Item
+} {
+	// Large recipe: ~64 KiB ASCII blob wrapped in a 2-element list.
+	recipe := make([]byte, 64*1024)
+	for i := range recipe {
+		recipe[i] = byte('A' + (i % 26))
+	}
+
+	// Nested list: 100 mixed leaf items.
+	leaves := make([]secs2.Item, 0, 100)
+	for i := range 100 {
+		switch i % 4 {
+		case 0:
+			leaves = append(leaves, secs2.A("item"))
+		case 1:
+			leaves = append(leaves, secs2.U4(uint32(i)))
+		case 2:
+			leaves = append(leaves, secs2.I2(int16(i)))
+		default:
+			leaves = append(leaves, secs2.BOOLEAN(i%2 == 0))
+		}
+	}
+
+	return []struct {
+		name string
+		item secs2.Item
+	}{
+		{"Small", secs2.A("ACK")},
+		{"List100", secs2.L(leaves...)},
+		{"Recipe64K", secs2.L(secs2.A("RECIPE_NAME"), secs2.A(string(recipe)))},
+	}
+}
+
+func BenchmarkDataMessage_Clone(b *testing.B) {
+	for _, p := range cloneBenchPayloads() {
+		b.Run(p.name, func(b *testing.B) {
+			msg, err := NewDataMessage(1, 1, true, 1234, GenerateMsgSystemBytes(), p.item.Clone())
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				cloned := msg.Clone()
+				cloned.Free()
+			}
+		})
+	}
+}
+
+func BenchmarkDataMessage_CloneCodec(b *testing.B) {
+	for _, p := range cloneBenchPayloads() {
+		b.Run(p.name, func(b *testing.B) {
+			msg, err := NewDataMessage(1, 1, true, 1234, GenerateMsgSystemBytes(), p.item.Clone())
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				codec := msg.CloneCodec()
+				cloned, _ := codec.(*DataMessage)
+				cloned.Free()
+			}
+		})
+	}
+}

--- a/hsms/clone_fanout_bench_test.go
+++ b/hsms/clone_fanout_bench_test.go
@@ -1,0 +1,126 @@
+package hsms
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/arloliu/go-secs/secs2"
+)
+
+// snapshotRelayPayloads builds the five canonical payloads for the SnapshotForRelay
+// gate benchmark.  Each payload is constructed once per benchmark binary run.
+func snapshotRelayPayloads() []struct {
+	name string
+	item secs2.Item
+} {
+	// ascii64k: 2-element list with a 64 KiB ASCII string leaf.
+	ascii64k := secs2.L(secs2.A("RECIPE_NAME"), secs2.A(strings.Repeat("A", 64*1024)))
+
+	// bin64k: 2-element list with a 64 KiB binary blob.
+	binData := make([]byte, 64*1024)
+	bin64k := secs2.L(secs2.A("MAP"), secs2.B(binData))
+
+	// list100: flat list of 100 ASCII items.
+	list100Items := make([]secs2.Item, 100)
+	for i := range list100Items {
+		list100Items[i] = secs2.A("item0001")
+	}
+	list100 := secs2.L(list100Items...)
+
+	// list1000: flat list of 1000 ASCII items.
+	list1000Items := make([]secs2.Item, 1000)
+	for i := range list1000Items {
+		list1000Items[i] = secs2.A("item0001")
+	}
+	list1000 := secs2.L(list1000Items...)
+
+	// nested256: depth-4, branching-factor-4 tree of secs2.A("leaf").
+	// Total leaves: 4^4 = 256.
+	nested256 := buildFanoutNestedList(4, 4)
+
+	return []struct {
+		name string
+		item secs2.Item
+	}{
+		{"ascii64k", ascii64k},
+		{"bin64k", bin64k},
+		{"list100", list100},
+		{"list1000", list1000},
+		{"nested256", nested256},
+	}
+}
+
+// buildFanoutNestedList builds a tree of ListItems with the given branching
+// factor and depth.  Leaves are secs2.A("leaf") items.
+func buildFanoutNestedList(depth, branch int) secs2.Item {
+	if depth == 0 {
+		return secs2.A("leaf")
+	}
+	children := make([]secs2.Item, branch)
+	for i := range children {
+		children[i] = buildFanoutNestedList(depth-1, branch)
+	}
+
+	return secs2.L(children...)
+}
+
+// BenchmarkSnapshotForRelay_Deep_CloneSerialize is the Phase-1 baseline: a full
+// structural deep clone followed by serialization.  This is the cost that
+// SnapshotForRelay must beat on every payload.
+func BenchmarkSnapshotForRelay_Deep_CloneSerialize(b *testing.B) {
+	for _, p := range snapshotRelayPayloads() {
+		b.Run(p.name, func(b *testing.B) {
+			msg, err := NewDataMessage(1, 1, true, 1234, GenerateMsgSystemBytes(), p.item.Clone())
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				c := msg.Clone()
+				_ = c.ToBytes()
+				c.Free()
+			}
+		})
+	}
+}
+
+// BenchmarkSnapshotForRelay_Snapshot_CloneSerialize is the relay path: SnapshotForRelay
+// followed by ToBytes.  The snapshot owns the pre-serialized frame; ToBytes
+// returns it verbatim without re-encoding.  Must beat Deep_CloneSerialize in
+// both ns/op and allocs/op on every payload — this is the hard gate.
+func BenchmarkSnapshotForRelay_Snapshot_CloneSerialize(b *testing.B) {
+	for _, p := range snapshotRelayPayloads() {
+		b.Run(p.name, func(b *testing.B) {
+			msg, err := NewDataMessage(1, 1, true, 1234, GenerateMsgSystemBytes(), p.item.Clone())
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				c := msg.SnapshotForRelay()
+				_ = c.ToBytes()
+				c.Free()
+			}
+		})
+	}
+}
+
+// BenchmarkSnapshotForRelay_Snapshot_Structural measures the decode-on-access cost:
+// the documented trade-off when a fan-out consumer needs item structure rather
+// than just forwarding the wire bytes.
+func BenchmarkSnapshotForRelay_Snapshot_Structural(b *testing.B) {
+	for _, p := range snapshotRelayPayloads() {
+		b.Run(p.name, func(b *testing.B) {
+			msg, err := NewDataMessage(1, 1, true, 1234, GenerateMsgSystemBytes(), p.item.Clone())
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				c := msg.SnapshotForRelay()
+				_, _ = c.Item().Get(0)
+				c.Free()
+			}
+		})
+	}
+}

--- a/hsms/clone_fanout_test.go
+++ b/hsms/clone_fanout_test.go
@@ -1,0 +1,110 @@
+package hsms
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/arloliu/go-secs/secs2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotForRelay covers DataMessage.SnapshotForRelay behaviour.
+func TestSnapshotForRelay(t *testing.T) {
+	t.Run("byte identity", func(t *testing.T) {
+		// SnapshotForRelay().ToBytes() must be byte-equal to msg.ToBytes() (same frame).
+		msg, err := NewDataMessage(1, 13, true, 0x1234, []byte{0x00, 0x00, 0x00, 0x01},
+			secs2.NewASCIIItem("hello"))
+		require.NoError(t, err)
+		defer msg.Free()
+
+		clone := msg.SnapshotForRelay()
+		defer clone.Free()
+
+		require.True(t, bytes.Equal(msg.ToBytes(), clone.ToBytes()),
+			"SnapshotForRelay().ToBytes() must be byte-equal to msg.ToBytes()")
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		// A DataMessage with an empty item serializes to a valid 14-byte frame;
+		// SnapshotForRelay must reproduce those 14 bytes exactly.
+		msg, err := NewDataMessage(0, 0, false, 0x0000, []byte{0, 0, 0, 0},
+			secs2.NewEmptyItem())
+		require.NoError(t, err)
+		defer msg.Free()
+
+		clone := msg.SnapshotForRelay()
+		defer clone.Free()
+
+		cloneBytes := clone.ToBytes()
+		require.Equal(t, 14, len(cloneBytes), "empty body clone frame must be exactly 14 bytes")
+		require.True(t, bytes.Equal(msg.ToBytes(), cloneBytes),
+			"empty body SnapshotForRelay().ToBytes() must equal msg.ToBytes()")
+	})
+
+	t.Run("independent structural access", func(t *testing.T) {
+		// Mutating the clone's child item via Item().Get(i).SetValues must not
+		// affect the source message's item tree.
+		msg, err := NewDataMessage(6, 11, true, 0x0001, []byte{0, 0, 0, 1},
+			secs2.L(secs2.A("original")))
+		require.NoError(t, err)
+		defer msg.Free()
+
+		clone := msg.SnapshotForRelay()
+		defer clone.Free()
+
+		// Mutate the clone's first child.
+		child, err := clone.Item().Get(0)
+		require.NoError(t, err)
+		require.NoError(t, child.SetValues("mutated"))
+
+		// Source item must remain untouched.
+		srcChild, err := msg.Item().Get(0)
+		require.NoError(t, err)
+		srcStr, err := srcChild.ToASCII()
+		require.NoError(t, err)
+		require.Equal(t, "original", srcStr,
+			"source item must not be affected by clone mutation")
+	})
+
+	t.Run("relay never decodes", func(t *testing.T) {
+		// A relay that only calls ToBytes() on the clone must not trigger
+		// item decode (snapshotMessage.item stays nil).
+		msg, err := NewDataMessage(1, 13, true, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("relay"))
+		require.NoError(t, err)
+		defer msg.Free()
+
+		clone := msg.SnapshotForRelay()
+		defer clone.Free()
+
+		// ToBytes-only relay path.
+		_ = clone.ToBytes()
+
+		// Type-assert to probe internal state (test is in-package).
+		snap, ok := clone.(*snapshotMessage)
+		require.True(t, ok, "SnapshotForRelay must return a *snapshotMessage")
+		require.Nil(t, snap.item, "relay-only clone must not decode the item")
+	})
+
+	t.Run("concurrent serialize no race", func(t *testing.T) {
+		// Serialize original and clone concurrently 200 times under -race.
+		for range 200 {
+			func() {
+				msg, err := NewDataMessage(1, 1, true, 1234, GenerateMsgSystemBytes(),
+					secs2.L(secs2.A("aaa"), secs2.A("bbb"), secs2.A("ccc")))
+				require.NoError(t, err)
+				defer msg.Free()
+
+				clone := msg.SnapshotForRelay()
+				defer clone.Free()
+
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() { defer wg.Done(); _ = msg.ToBytes() }()
+				go func() { defer wg.Done(); _ = clone.ToBytes() }()
+				wg.Wait()
+			}()
+		}
+	})
+}

--- a/hsms/clone_race_test.go
+++ b/hsms/clone_race_test.go
@@ -1,0 +1,29 @@
+package hsms
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/arloliu/go-secs/secs2"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression guard for the shallow-ListItem.Clone race: a cloned list message
+// and its original must be safe to serialize concurrently. Run under -race.
+// Pre-fix (shallow clone) this races on shared child rawBytes at
+// secs2/ascii.go (write) reached via ListItem.ToBytes / DataMessage.ToBytes.
+func TestDataMessage_Clone_ConcurrentSerialize_NoRace(t *testing.T) {
+	for range 200 {
+		msg, err := NewDataMessage(1, 1, true, 1234, GenerateMsgSystemBytes(),
+			secs2.L(secs2.A("aaaa"), secs2.A("bbbb"), secs2.A("cccc")))
+		require.NoError(t, err)
+
+		clone := msg.Clone()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = msg.ToBytes() }()
+		go func() { defer wg.Done(); _ = clone.ToBytes() }()
+		wg.Wait()
+	}
+}

--- a/hsms/data_msg.go
+++ b/hsms/data_msg.go
@@ -1,6 +1,7 @@
 package hsms
 
 import (
+	"encoding"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -463,9 +464,22 @@ func (msg *DataMessage) Free() {
 	}
 }
 
-// Clone returns a duplicated Message
+// Clone returns an independent deep copy of the message.
+//
+// The clone shares no mutable state with the original: the system bytes are
+// value-copied (no shared backing array) and the data item is deep-cloned via
+// secs2.Item.Clone. A nil data item becomes an empty item in the clone. This
+// makes the result safe to hand to a concurrent consumer (for example a fan-out
+// or broadcast path) and to mutate independently of the source.
+//
+// The clone is a fresh instance, not drawn from the message pool, with its freed
+// state reset; calling Free on it returns it (and its item) to the pool. The
+// source message's error (see SetError) is not propagated to the clone.
 //
 // It implements the Clone method of the HSMSMessage interface.
+//
+// Returns:
+//   - HSMSMessage: a new *DataMessage independent of the receiver.
 func (msg *DataMessage) Clone() HSMSMessage {
 	cloned := &DataMessage{
 		stream:      msg.stream,
@@ -481,6 +495,63 @@ func (msg *DataMessage) Clone() HSMSMessage {
 	}
 
 	return cloned
+}
+
+// CloneCodec returns an independent deep copy of the message typed only as a
+// binary codec (encoding.BinaryMarshaler + encoding.BinaryUnmarshaler).
+//
+// It is a thin wrapper over [DataMessage.Clone]; the deep-copy and concurrency
+// guarantees documented there apply unchanged. Its sole purpose is the return
+// type: a caller that knows only the codec contract — not the concrete
+// *DataMessage type — can obtain an independent copy without importing this
+// package, which lets external code declare a matching capability interface and
+// satisfy it covariantly.
+//
+// Because the copy is deep (the data item, and hence its lazily populated
+// serialized-bytes cache, is cloned), serializing the result is safe to do
+// concurrently with serializing the original; neither observes the other's
+// cache writes.
+//
+// Returns:
+//   - a new *DataMessage, independent of the receiver, exposed as the codec pair.
+func (msg *DataMessage) CloneCodec() interface {
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+} {
+	return msg.Clone()
+}
+
+// SnapshotForRelay returns an independent, relay-optimized snapshot of the
+// message. It serializes the message once via ToBytes and serves those bytes
+// from the returned message's ToBytes without re-encoding; the item structure is
+// decoded lazily only if a structural method (Item, ToDataMessage, …) is called
+// on the result.
+//
+// Use it only for the relay / broadcast / shadow path — clone then
+// serialize-and-forward, without inspecting the item structure. For that pattern
+// it is dramatically cheaper than Clone (no structural deep copy, no re-encode).
+// Use Clone for a structural deep copy: if the consumer accesses items,
+// SnapshotForRelay is slower than Clone, because it pays serialize-at-clone plus
+// lazy-decode-at-access where Clone simply deep-copies the live item tree.
+//
+// Item() on the returned message yields a lazily-decoded item — use the
+// secs2.Item interface, not concrete-type assertions, to remain compatible with
+// future implementations.
+//
+// Returns an HSMSMessage backed by an internal snapshot type. The dynamic type
+// is not *DataMessage: a consumer that needs a concrete *DataMessage (for
+// example the in-process handler fan-out path, whose channels carry
+// *DataMessage) must call ToDataMessage, which is more expensive than Clone.
+//
+// The returned message is intended for a single consumer; create one snapshot
+// per concurrent recipient.
+//
+// Lifetime: unlike DataMessage.ToBytes (which allocates a fresh buffer each
+// call), the returned message's ToBytes may return its internal frame buffer
+// directly until structure is accessed. Treat the ToBytes result as read-only
+// and do not retain it for mutation.
+func (msg *DataMessage) SnapshotForRelay() HSMSMessage {
+	return &snapshotMessage{frame: msg.ToBytes()} // ToBytes returns a fresh owned buffer
 }
 
 func (msg *DataMessage) generateHeader(header []byte) {

--- a/hsms/data_msg_test.go
+++ b/hsms/data_msg_test.go
@@ -252,6 +252,37 @@ func TestDataMessage_CloneMutationIndependence(t *testing.T) {
 	require.Equal(uint32(0xDEADBEEF), cloned.ID())
 }
 
+func TestDataMessage_CloneCodec(t *testing.T) {
+	require := require.New(t)
+
+	msg, err := NewDataMessage(1, 1, true, 42, []byte{0x12, 0x34, 0x56, 0x78}, secs2.A("hello"))
+	require.NoError(err)
+
+	// The returned value satisfies the standard binary codec contract without the
+	// caller knowing the concrete *DataMessage type.
+	codec := msg.CloneCodec()
+
+	// It is an independent instance, not the original.
+	cloned, ok := codec.(*DataMessage)
+	require.True(ok)
+	require.NotSame(msg, cloned)
+
+	// Serializing through the codec interface yields the same wire bytes as the
+	// original, and round-trips back into a fresh DataMessage.
+	wire, err := codec.MarshalBinary()
+	require.NoError(err)
+	require.Equal(msg.ToBytes(), wire)
+
+	var dst DataMessage
+	require.NoError(dst.UnmarshalBinary(wire))
+	require.Equal(msg.SystemBytes(), dst.SystemBytes())
+
+	// Mutating the clone leaves the original untouched (independent deep copy).
+	cloned.SetID(0xDEADBEEF)
+	require.Equal(uint32(0xDEADBEEF), cloned.ID())
+	require.Equal(uint32(0x12345678), msg.ID())
+}
+
 func TestDataMessage_MarshalUnmarshalRoundTrip(t *testing.T) {
 	require := require.New(t)
 

--- a/hsms/decode.go
+++ b/hsms/decode.go
@@ -334,6 +334,25 @@ func (d *hsmsDecoder) decodeMessageText() (secs2.Item, error) { //nolint:cyclop,
 	case secs2.Float64FormatCode:
 		return d.decodeFloatItem(8, length)
 
+	case secs2.JIS8FormatCode:
+		value, err := d.readString(length)
+		if err != nil {
+			return nil, err
+		}
+		return secs2.NewJIS8Item(value), nil
+
+	case secs2.LocalizedStrFormatCode:
+		if length < 2 {
+			return nil, fmt.Errorf("localized string body too short: %d", length)
+		}
+		body, err := d.read(length)
+		if err != nil {
+			return nil, err
+		}
+		lsh := uint16(body[0])<<8 | uint16(body[1])
+
+		return secs2.NewLocalizedStrItem(lsh, secs2.BytesToString(body[2:])), nil
+
 	default:
 		return nil, errors.New("invalid format")
 	}

--- a/hsms/decode_jis8_localized_test.go
+++ b/hsms/decode_jis8_localized_test.go
@@ -1,0 +1,34 @@
+package hsms
+
+import (
+	"testing"
+
+	"github.com/arloliu/go-secs/secs2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeSECS2Item_JIS8RoundTrip(t *testing.T) {
+	require := require.New(t)
+	src := secs2.J("abc")
+	got, err := DecodeSECS2Item(src.ToBytes())
+	require.NoError(err)
+	require.Equal(src.ToBytes(), got.ToBytes())
+	s, err := got.ToJIS8()
+	require.NoError(err)
+	require.Equal("abc", s)
+}
+
+func TestDecodeSECS2Item_LocalizedStrRoundTrip(t *testing.T) {
+	require := require.New(t)
+	// secs2.W is NewUTF8StrItem(value) — use NewLocalizedStrItem to set a specific LSH
+	src := secs2.NewLocalizedStrItem(0x1234, "héllo")
+	got, err := DecodeSECS2Item(src.ToBytes())
+	require.NoError(err)
+	require.Equal(src.ToBytes(), got.ToBytes())
+	s, err := got.ToLocalizedStr()
+	require.NoError(err)
+	require.Equal("héllo", s)
+	lsh, err := got.ToLocalizedStrHeader()
+	require.NoError(err)
+	require.Equal(uint16(0x1234), lsh)
+}

--- a/hsms/fanout_snapshot.go
+++ b/hsms/fanout_snapshot.go
@@ -1,0 +1,321 @@
+package hsms
+
+import (
+	"encoding/binary"
+	"errors"
+
+	"github.com/arloliu/go-secs/secs2"
+)
+
+// snapshotMessage is an unexported HSMSMessage that owns a complete serialized
+// HSMS frame ([4-byte length][10-byte header][item bytes]).
+//
+// It serves the decode-free relay path: ToBytes() returns the raw frame verbatim
+// until the caller performs a structural access (Item, ToDataMessage, …), at which
+// point the item bytes are lazily decoded once and cached.
+//
+// The frame is GC-owned and never pooled.  snapshotMessage is not safe for
+// concurrent use without external locking (single-owner assumption).
+type snapshotMessage struct {
+	frame     []byte     // owned full frame [4 len][10 header][item]; never reused/shared
+	err       error      // message-level error (SetError); separate from decodeErr
+	item      secs2.Item // lazily decoded; nil until first structural access
+	decodeErr error      // lazy item-decode failure; separate from err
+}
+
+// Compile-time interface assertion.
+var _ HSMSMessage = (*snapshotMessage)(nil)
+
+// dataItem is the internal helper that performs lazy decode.
+// It clears decodeErr, then decodes once, caches decoded.Clone() and frees the intermediate.
+// Sets/clears ONLY decodeErr — never s.err.
+func (s *snapshotMessage) dataItem() secs2.Item {
+	if s.item == nil {
+		s.decodeErr = nil
+		if len(s.frame) <= 14 {
+			s.item = secs2.NewEmptyItem()
+		} else {
+			decoded, err := DecodeSECS2Item(s.frame[14:])
+			if err != nil {
+				s.item, s.decodeErr = secs2.NewEmptyItem(), err
+			} else {
+				s.item = decoded.Clone()
+				decoded.Free()
+			}
+		}
+	}
+
+	return s.item
+}
+
+// Type returns DataMsgType for all snapshot messages.
+func (s *snapshotMessage) Type() int { return DataMsgType }
+
+// IsDataMessage returns true.
+func (s *snapshotMessage) IsDataMessage() bool { return true }
+
+// IsControlMessage returns false.
+func (s *snapshotMessage) IsControlMessage() bool { return false }
+
+// ToControlMessage always returns (nil, false).
+func (s *snapshotMessage) ToControlMessage() (*ControlMessage, bool) { return nil, false }
+
+// SessionID returns the session ID decoded decode-free from frame[4:6].
+func (s *snapshotMessage) SessionID() uint16 {
+	if len(s.frame) < 14 {
+		return 0
+	}
+
+	return binary.BigEndian.Uint16(s.frame[4:6])
+}
+
+// SetSessionID patches session ID in frame[4:6] in place.
+func (s *snapshotMessage) SetSessionID(sessionID uint16) {
+	if len(s.frame) < 14 {
+		return
+	}
+	binary.BigEndian.PutUint16(s.frame[4:6], sessionID)
+}
+
+// StreamCode returns the stream code (low 7 bits of frame[6]) decode-free.
+func (s *snapshotMessage) StreamCode() uint8 {
+	if len(s.frame) < 14 {
+		return 0
+	}
+
+	return s.frame[6] & 0x7F
+}
+
+// FunctionCode returns the function code from frame[7] decode-free.
+func (s *snapshotMessage) FunctionCode() uint8 {
+	if len(s.frame) < 14 {
+		return 0
+	}
+
+	return s.frame[7]
+}
+
+// WaitBit returns true if the wait bit (MSB of frame[6]) is set, decode-free.
+func (s *snapshotMessage) WaitBit() bool {
+	if len(s.frame) < 14 {
+		return false
+	}
+
+	return s.frame[6]&waitBitMask != 0
+}
+
+// ID returns a numeric representation of system bytes from frame[10:14] decode-free.
+func (s *snapshotMessage) ID() uint32 {
+	if len(s.frame) < 14 {
+		return 0
+	}
+
+	return binary.BigEndian.Uint32(s.frame[10:14])
+}
+
+// SetID patches system bytes in frame[10:14] in place.
+func (s *snapshotMessage) SetID(id uint32) {
+	if len(s.frame) < 14 {
+		return
+	}
+	binary.BigEndian.PutUint32(s.frame[10:14], id)
+}
+
+// SystemBytes returns a copy of the 4 system bytes from frame[10:14].
+// A copy is returned (not an alias into the frame) to match the documented
+// SystemBytes lifetime contract.
+func (s *snapshotMessage) SystemBytes() []byte {
+	if len(s.frame) < 14 {
+		return []byte{0, 0, 0, 0}
+	}
+	result := make([]byte, 4)
+	copy(result, s.frame[10:14])
+
+	return result
+}
+
+// SetSystemBytes patches the system bytes in frame[10:14] in place.
+// Returns ErrInvalidSystemBytes if systemBytes is not exactly 4 bytes.
+func (s *snapshotMessage) SetSystemBytes(systemBytes []byte) error {
+	if len(systemBytes) != 4 {
+		return ErrInvalidSystemBytes
+	}
+	if len(s.frame) < 14 {
+		return ErrInvalidHeaderLength
+	}
+	copy(s.frame[10:14], systemBytes)
+
+	return nil
+}
+
+// Header returns a copy of the 10-byte header from frame[4:14].
+func (s *snapshotMessage) Header() []byte {
+	if len(s.frame) < 14 {
+		return make([]byte, 10)
+	}
+	result := make([]byte, 10)
+	copy(result, s.frame[4:14])
+
+	return result
+}
+
+// SetHeader replaces the 10-byte header section (frame[4:14]) in place.
+// Validates PType == 0 and SType == DataMsgType, mirroring DataMessage.SetHeader.
+func (s *snapshotMessage) SetHeader(header []byte) error {
+	if len(header) != 10 {
+		return ErrInvalidHeaderLength
+	}
+	if header[4] != 0 {
+		return ErrInvalidPType
+	}
+	if header[5] != DataMsgType {
+		return ErrInvalidDataMsgSType
+	}
+	if len(s.frame) < 14 {
+		return ErrInvalidHeaderLength
+	}
+	copy(s.frame[4:14], header)
+
+	return nil
+}
+
+// Error returns errors.Join(s.err, s.decodeErr).
+// Returns nil when both are nil.
+func (s *snapshotMessage) Error() error {
+	return errors.Join(s.err, s.decodeErr)
+}
+
+// SetError sets the message-level error (s.err only).
+// It never touches decodeErr or the cached item.
+func (s *snapshotMessage) SetError(err error) {
+	s.err = err
+}
+
+// Item triggers lazy decode (if not yet done) and returns the cached item.
+// Structural access via this method may set s.decodeErr but never clears s.err.
+func (s *snapshotMessage) Item() secs2.Item {
+	return s.dataItem()
+}
+
+// ToBytes serializes the message.
+//
+// If item == nil (no structural access performed yet), the raw frame is returned
+// verbatim — the decode-free relay path.
+//
+// If item != nil (structural access was performed and item may have been mutated),
+// a fresh byte slice is built as [4-byte len][frame[4:14] header][item.ToBytes()],
+// so any in-memory mutations to the cached item are reflected.
+func (s *snapshotMessage) ToBytes() []byte {
+	if s.item == nil {
+		return s.frame
+	}
+
+	// Rebuild with the (potentially mutated) cached item.
+	itemBytes := s.item.ToBytes()
+	totalBytes := 14 + len(itemBytes)
+	result := make([]byte, totalBytes)
+	binary.BigEndian.PutUint32(result[0:4], uint32(totalBytes-4)) //nolint:gosec
+	copy(result[4:14], s.frame[4:14])
+	copy(result[14:], itemBytes)
+
+	return result
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s *snapshotMessage) MarshalBinary() ([]byte, error) {
+	return s.ToBytes(), nil
+}
+
+// UnmarshalBinary validates the input via DecodeHSMSMessage, requires a data
+// message, and re-snapshots the receiver on success.  Invalid input returns an
+// error and leaves the receiver unchanged.
+func (s *snapshotMessage) UnmarshalBinary(b []byte) error {
+	m, err := DecodeHSMSMessage(b)
+	if err != nil {
+		return err
+	}
+
+	dm, ok := m.ToDataMessage()
+	if !ok {
+		m.Free()
+		return errors.New("expected data message")
+	}
+
+	// Replace receiver state with the validated frame.
+	s.frame = append([]byte(nil), b...)
+	s.item = nil
+	s.decodeErr = nil
+	s.err = nil
+
+	dm.Free()
+
+	return nil
+}
+
+// Free releases the cached item if present.
+// The frame is GC-owned and is never pooled.
+// Free never decodes.
+func (s *snapshotMessage) Free() {
+	if s.item != nil {
+		s.item.Free()
+		s.item = nil
+	}
+}
+
+// Clone returns an independent copy of the snapshot.
+//
+// If item == nil (not yet decoded), returns a new snapshotMessage with a copied
+// frame and the message-level error — a lazy clone that will decode on first
+// structural access.
+//
+// If item != nil (decoded; may be mutated), delegates to ToDataMessage() which
+// clones the item and builds an independent *DataMessage.  If ToDataMessage()
+// fails (rare — the frame was already validated), falls back to the frame-copy
+// lazy clone (preserves serialized bytes; note this loses any uncommitted
+// in-memory item mutation, acceptable for the rare error path).
+func (s *snapshotMessage) Clone() HSMSMessage {
+	if s.item == nil {
+		return &snapshotMessage{
+			frame: append([]byte(nil), s.frame...),
+			err:   s.err,
+		}
+	}
+
+	dm, ok := s.ToDataMessage()
+	if !ok {
+		// Fallback: frame-copy lazy clone.
+		return &snapshotMessage{
+			frame: append([]byte(nil), s.frame...),
+			err:   s.err,
+		}
+	}
+
+	return dm
+}
+
+// ToDataMessage builds a fresh, independent *DataMessage from the snapshot's
+// header and item on every call.  The result is never shared or cached.
+//
+// s.Item().Clone() is used so that the returned message owns an independent item —
+// sharing s.item would allow the caller's Free() to free the snapshot's cached item.
+//
+// If s.Error() != nil, the error is propagated to the returned message via SetError.
+func (s *snapshotMessage) ToDataMessage() (*DataMessage, bool) {
+	dm, err := NewDataMessage(
+		s.StreamCode(),
+		s.FunctionCode(),
+		s.WaitBit(),
+		s.SessionID(),
+		s.SystemBytes(),
+		s.Item().Clone(),
+	)
+	if err != nil {
+		return nil, false
+	}
+
+	if s.Error() != nil {
+		dm.SetError(s.Error())
+	}
+
+	return dm, true
+}

--- a/hsms/fanout_snapshot_test.go
+++ b/hsms/fanout_snapshot_test.go
@@ -1,0 +1,504 @@
+package hsms
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/arloliu/go-secs/secs2"
+	"github.com/stretchr/testify/require"
+)
+
+// newSnapshotForTest builds a snapshotMessage from a DataMessage's serialized frame.
+func newSnapshotForTest(dm *DataMessage) *snapshotMessage {
+	return &snapshotMessage{frame: append([]byte(nil), dm.ToBytes()...)}
+}
+
+// TestSnapshotMessage is the main test suite for snapshotMessage.
+func TestSnapshotMessage(t *testing.T) {
+	t.Run("interface assertion", func(t *testing.T) {
+		var _ HSMSMessage = (*snapshotMessage)(nil)
+	})
+
+	t.Run("ToBytes decode-free relay", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 13, true, 0x1234, []byte{0x00, 0x00, 0x00, 0x01},
+			secs2.NewASCIIItem("hello"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		want := dm.ToBytes()
+		got := s.ToBytes()
+		require.Equal(t, want, got, "ToBytes should return frame verbatim before any structural access")
+		require.Nil(t, s.item, "item must remain nil — no decode triggered")
+	})
+
+	t.Run("header reads decode-free", func(t *testing.T) {
+		sysBytes := []byte{0xAA, 0xBB, 0xCC, 0xDD}
+		dm, err := NewDataMessage(6, 11, true, 0xABCD, sysBytes,
+			secs2.NewASCIIItem("test"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		require.Equal(t, DataMsgType, s.Type(), "Type")
+		require.True(t, s.IsDataMessage(), "IsDataMessage")
+		require.False(t, s.IsControlMessage(), "IsControlMessage")
+		cm, ok := s.ToControlMessage()
+		require.Nil(t, cm)
+		require.False(t, ok, "ToControlMessage should return (nil,false)")
+
+		require.Equal(t, uint16(0xABCD), s.SessionID(), "SessionID")
+		require.Equal(t, uint8(6), s.StreamCode(), "StreamCode")
+		require.Equal(t, uint8(11), s.FunctionCode(), "FunctionCode")
+		require.True(t, s.WaitBit(), "WaitBit")
+		require.Equal(t, binary.BigEndian.Uint32(sysBytes), s.ID(), "ID")
+		require.Equal(t, sysBytes, s.SystemBytes(), "SystemBytes")
+		require.Equal(t, dm.Header(), s.Header(), "Header")
+
+		require.Nil(t, s.item, "item must remain nil after header-only reads")
+	})
+
+	t.Run("SystemBytes returns copy not alias", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 1, false, 0x0001, []byte{0x01, 0x02, 0x03, 0x04},
+			secs2.NewEmptyItem())
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		sb := s.SystemBytes()
+		sb[0] = 0xFF // mutate the returned slice
+		require.Equal(t, byte(0x01), s.frame[10], "frame must not be aliased by SystemBytes()")
+	})
+
+	t.Run("Item lazy decode", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 13, true, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("lazy"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		require.Nil(t, s.item, "item nil before access")
+
+		item := s.Item()
+		require.NotNil(t, item, "Item() must not return nil")
+		require.NotNil(t, s.item, "item field set after Item()")
+
+		str, err := item.ToASCII()
+		require.NoError(t, err)
+		require.Equal(t, "lazy", str, "decoded ASCII value")
+
+		// Second call returns same cached item
+		item2 := s.Item()
+		require.Equal(t, item, item2, "Item() must return cached item on second call")
+	})
+
+	t.Run("mutation reflected in ToBytes via SetValues", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 13, true, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("original"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		originalFrame := dm.ToBytes()
+
+		// Trigger decode
+		_ = s.Item()
+		require.NotNil(t, s.item)
+
+		// Mutate via SetValues
+		err = s.Item().SetValues("changed")
+		require.NoError(t, err)
+
+		rebuilt := s.ToBytes()
+		require.NotEqual(t, originalFrame, rebuilt, "ToBytes must rebuild after item mutation")
+
+		// Verify the rebuilt message decodes correctly
+		decoded, err := DecodeHSMSMessage(rebuilt)
+		require.NoError(t, err)
+		ddm, ok := decoded.ToDataMessage()
+		require.True(t, ok)
+		defer ddm.Free()
+		str, err := ddm.Item().ToASCII()
+		require.NoError(t, err)
+		require.Equal(t, "changed", str)
+	})
+
+	t.Run("binary alias mutation reflected in ToBytes", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 13, false, 0x0002, []byte{0, 0, 0, 2},
+			secs2.NewBinaryItem([]byte{0x01, 0x02, 0x03}))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		// Trigger decode — item is now cached as a Clone() with no rawBytes
+		item := s.Item()
+		require.NotNil(t, s.item)
+
+		// ToBinary() returns the item's internal values alias
+		bs, err := item.ToBinary()
+		require.NoError(t, err)
+		bs[0] = 0xFF
+
+		// ToBytes rebuilds (item != nil), reflecting the in-place mutation
+		rebuilt := s.ToBytes()
+		decoded, err := DecodeHSMSMessage(rebuilt)
+		require.NoError(t, err)
+		ddm, ok := decoded.ToDataMessage()
+		require.True(t, ok)
+		defer ddm.Free()
+		got, err := ddm.Item().ToBinary()
+		require.NoError(t, err)
+		require.Equal(t, byte(0xFF), got[0], "in-place mutation via ToBinary alias must be reflected in ToBytes")
+	})
+
+	t.Run("header setters patch in place decode-free", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 1, false, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("test"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		s.SetSessionID(0xBEEF)
+		require.Equal(t, uint16(0xBEEF), s.SessionID())
+		require.Nil(t, s.item, "item must remain nil after SetSessionID")
+
+		s.SetID(0xDEADBEEF)
+		require.Equal(t, uint32(0xDEADBEEF), s.ID())
+		require.Nil(t, s.item, "item must remain nil after SetID")
+
+		newSys := []byte{0x11, 0x22, 0x33, 0x44}
+		require.NoError(t, s.SetSystemBytes(newSys))
+		require.Equal(t, newSys, s.SystemBytes())
+		require.Nil(t, s.item, "item must remain nil after SetSystemBytes")
+
+		require.Error(t, s.SetSystemBytes([]byte{0x01, 0x02}), "short systemBytes must error")
+
+		hdr := make([]byte, 10)
+		hdr[0] = 0x00
+		hdr[1] = 0x01 // sessionID = 1
+		hdr[2] = 0x05 // stream = 5, no wait
+		hdr[3] = 0x02 // function = 2
+		hdr[4] = 0x00 // PType
+		hdr[5] = 0x00 // SType (data)
+		hdr[6] = 0xAA
+		hdr[7] = 0xBB
+		hdr[8] = 0xCC
+		hdr[9] = 0xDD
+		require.NoError(t, s.SetHeader(hdr))
+		require.Equal(t, hdr, s.Header())
+
+		badHdr := make([]byte, 10)
+		badHdr[4] = 1
+		require.Error(t, s.SetHeader(badHdr), "nonzero PType must error")
+
+		badHdr2 := make([]byte, 10)
+		badHdr2[5] = 1
+		require.Error(t, s.SetHeader(badHdr2), "nonzero SType must error")
+
+		require.Error(t, s.SetHeader([]byte{0x00, 0x01}), "wrong header length must error")
+
+		// Verify ToBytes frame reflects in-place changes (item still nil)
+		require.Nil(t, s.item)
+		tb := s.ToBytes()
+		require.Equal(t, uint16(1), binary.BigEndian.Uint16(tb[4:6]), "sessionID in frame")
+	})
+
+	t.Run("empty body snapshot", func(t *testing.T) {
+		dm, err := NewDataMessage(0, 0, false, 0x0000, []byte{0, 0, 0, 0},
+			secs2.NewEmptyItem())
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		require.Equal(t, 14, len(s.frame), "empty frame must be exactly 14 bytes")
+
+		item := s.Item()
+		require.NotNil(t, item)
+		require.True(t, item.IsEmpty(), "item must be empty for no-body message")
+		require.Equal(t, dm.ToBytes(), s.ToBytes())
+		require.Nil(t, s.Error(), "no error expected for valid empty message")
+	})
+
+	t.Run("decode error does not panic; Error returns decodeErr", func(t *testing.T) {
+		// Build a 14-byte header + 3 bytes of malformed item
+		frame := make([]byte, 17)
+		binary.BigEndian.PutUint32(frame[0:4], uint32(13)) // msgLen = 17-4 = 13
+		frame[4] = 0x00                                    // sessionID
+		frame[5] = 0x01
+		frame[6] = 0x01 // stream 1
+		frame[7] = 0x01 // function 1
+		frame[8] = 0x00 // PType
+		frame[9] = 0x00 // SType
+		// malformed item: format byte 0xFF is invalid format code
+		frame[14] = 0xFF
+		frame[15] = 0x00
+		frame[16] = 0x00
+
+		s := &snapshotMessage{frame: append([]byte(nil), frame...)}
+		item := s.Item()
+		require.NotNil(t, item, "Item must return non-nil even on decode error")
+		require.NotNil(t, s.Error(), "Error() must be non-nil after decode failure")
+	})
+
+	t.Run("error-state separation: SetError survives successful Item()", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 13, false, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("ok"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		sentinel := errors.New("msg-level error")
+		s.SetError(sentinel)
+
+		// Successful Item() must not clear s.err
+		item := s.Item()
+		require.NotNil(t, item)
+		require.Nil(t, s.decodeErr, "decodeErr must remain nil after successful decode")
+		require.Equal(t, sentinel, s.err, "s.err must not be cleared by a successful Item()")
+		require.True(t, errors.Is(s.Error(), sentinel), "Error() must still contain sentinel after Item()")
+	})
+
+	t.Run("error-state separation: decode error + SetError both in Error()", func(t *testing.T) {
+		// Build frame with malformed item
+		frame := make([]byte, 15)
+		binary.BigEndian.PutUint32(frame[0:4], uint32(11)) // msgLen = 15-4 = 11
+		frame[6] = 0x01                                    // stream
+		frame[7] = 0x01                                    // function
+		frame[8] = 0x00                                    // PType
+		frame[9] = 0x00                                    // SType
+		frame[14] = 0xFF                                   // invalid format byte
+
+		s := &snapshotMessage{frame: append([]byte(nil), frame...)}
+		sentinel := errors.New("pre-set msg error")
+		s.SetError(sentinel)
+
+		_ = s.Item() // trigger decode error
+
+		combined := s.Error()
+		require.NotNil(t, combined)
+		require.True(t, errors.Is(combined, sentinel), "combined error must include sentinel")
+		require.NotNil(t, s.decodeErr, "decodeErr must be set after failed decode")
+	})
+
+	t.Run("ToDataMessage independence", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 13, true, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("fanout"))
+		require.NoError(t, err)
+		dm.Free()
+
+		// Build snapshot directly from bytes (after dm.Free)
+		dmAgain, err := NewDataMessage(1, 13, true, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("fanout"))
+		require.NoError(t, err)
+		s := newSnapshotForTest(dmAgain)
+		dmAgain.Free()
+
+		dm1, ok1 := s.ToDataMessage()
+		require.True(t, ok1)
+		require.NotNil(t, dm1)
+
+		dm2, ok2 := s.ToDataMessage()
+		require.True(t, ok2)
+		require.NotNil(t, dm2)
+
+		require.True(t, dm1 != dm2, "two ToDataMessage calls must return different *DataMessage pointers")
+
+		// Mutate dm1's item
+		err = dm1.Item().SetValues("mutated")
+		require.NoError(t, err)
+
+		// dm2 and snapshot must be unaffected
+		dm2str, err := dm2.Item().ToASCII()
+		require.NoError(t, err)
+		require.Equal(t, "fanout", dm2str, "dm2 item must be independent of dm1 mutation")
+
+		sstr, err := s.Item().ToASCII()
+		require.NoError(t, err)
+		require.Equal(t, "fanout", sstr, "snapshot item must be independent of dm1 mutation")
+
+		// Free dm1 then verify snapshot is safe
+		dm1.Free()
+		tb := s.ToBytes()
+		require.NotNil(t, tb, "ToBytes must be safe after dm1.Free()")
+
+		dm2.Free()
+		s.Free()
+	})
+
+	t.Run("UnmarshalBinary accept valid data message", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 13, true, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("unmarshal"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := &snapshotMessage{}
+		err = s.UnmarshalBinary(dm.ToBytes())
+		require.NoError(t, err)
+		require.NotNil(t, s.frame)
+		require.Equal(t, uint8(1), s.StreamCode())
+		require.Equal(t, uint8(13), s.FunctionCode())
+		require.True(t, s.WaitBit())
+		require.Equal(t, uint16(0x0001), s.SessionID())
+		require.Nil(t, s.item, "item must be nil after UnmarshalBinary (lazy)")
+		require.Nil(t, s.err)
+		require.Nil(t, s.decodeErr)
+		s.Free()
+	})
+
+	t.Run("UnmarshalBinary reject truncated frame", func(t *testing.T) {
+		s := &snapshotMessage{}
+		err := s.UnmarshalBinary([]byte{0x00, 0x00, 0x00, 0x0A, 0x00, 0x01, 0x01, 0x01})
+		require.Error(t, err, "truncated frame must be rejected")
+	})
+
+	t.Run("UnmarshalBinary reject length mismatch", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 1, false, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("x"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		frame := dm.ToBytes()
+		// Corrupt the length field
+		binary.BigEndian.PutUint32(frame[0:4], 9999)
+
+		s := &snapshotMessage{}
+		err = s.UnmarshalBinary(frame)
+		require.Error(t, err, "length mismatch must be rejected")
+	})
+
+	t.Run("UnmarshalBinary reject nonzero PType", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 1, false, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewEmptyItem())
+		require.NoError(t, err)
+		defer dm.Free()
+
+		frame := dm.ToBytes()
+		frame[8] = 0x01 // nonzero PType
+
+		// Fix the length field to match the (now corrupted) frame
+		binary.BigEndian.PutUint32(frame[0:4], uint32(len(frame)-4))
+
+		s := &snapshotMessage{}
+		err = s.UnmarshalBinary(frame)
+		require.Error(t, err, "nonzero PType must be rejected")
+	})
+
+	t.Run("UnmarshalBinary reject control SType", func(t *testing.T) {
+		// Build a valid control message frame (SType=SelectReq=1)
+		hdrBytes := []byte{0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01}
+		ctrl := NewControlMessage(hdrBytes, false)
+		frame, err := ctrl.MarshalBinary()
+		require.NoError(t, err)
+		ctrl.Free()
+
+		s := &snapshotMessage{}
+		err = s.UnmarshalBinary(frame)
+		require.Error(t, err, "control SType must be rejected")
+	})
+
+	t.Run("UnmarshalBinary reject malformed item", func(t *testing.T) {
+		// Frame with valid header but a malformed item (format byte only, no length bytes)
+		frame := make([]byte, 15)
+		binary.BigEndian.PutUint32(frame[0:4], uint32(11)) // 15-4=11
+		frame[4] = 0x00
+		frame[5] = 0x01  // sessionID
+		frame[6] = 0x01  // stream
+		frame[7] = 0x01  // function
+		frame[8] = 0x00  // PType
+		frame[9] = 0x00  // SType=data
+		frame[14] = 0x01 // lenBytesCount=1, formatCode=0 but no following length byte — truncated
+
+		s := &snapshotMessage{}
+		err := s.UnmarshalBinary(frame)
+		require.Error(t, err, "malformed item must be rejected")
+	})
+
+	t.Run("Clone independence undecoded", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 13, false, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("clonetest"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		require.Nil(t, s.item, "precondition: item nil")
+		cloned := s.Clone()
+		require.NotNil(t, cloned)
+
+		// Record original byte before mutating
+		origByte := s.frame[4]
+
+		// Mutate original frame
+		s.frame[4] ^= 0xFF
+
+		// Clone must be independent (cloned is a *snapshotMessage with its own frame copy)
+		clonedSnap, isSnap := cloned.(*snapshotMessage)
+		if isSnap {
+			require.Equal(t, origByte, clonedSnap.frame[4],
+				"undecoded clone must not alias original frame")
+		}
+		cloned.Free()
+	})
+
+	t.Run("Clone independence decoded", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 13, false, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("cloneafter"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		// Trigger decode
+		_ = s.Item()
+		require.NotNil(t, s.item)
+
+		cloned := s.Clone()
+		require.NotNil(t, cloned)
+
+		// Mutate snapshot's item after cloning
+		_ = s.Item().SetValues("mutated-original")
+
+		// Clone (returned as *DataMessage from ToDataMessage()) must be independent
+		clonedItem := cloned.Item()
+		str, err := clonedItem.ToASCII()
+		require.NoError(t, err)
+		require.Equal(t, "cloneafter", str, "decoded clone must not reflect post-clone mutation of original")
+
+		cloned.Free()
+	})
+
+	t.Run("MarshalBinary returns ToBytes", func(t *testing.T) {
+		dm, err := NewDataMessage(1, 1, false, 0x0001, []byte{0, 0, 0, 1},
+			secs2.NewASCIIItem("marshal"))
+		require.NoError(t, err)
+		defer dm.Free()
+
+		s := newSnapshotForTest(dm)
+		defer s.Free()
+
+		got, err := s.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, s.ToBytes(), got)
+	})
+}

--- a/secs2/ascii.go
+++ b/secs2/ascii.go
@@ -51,7 +51,10 @@ func WithASCIIStrictMode(enable bool) {
 // can only store a single string value.
 type ASCIIItem struct {
 	baseItem
-	value    []byte // The ASCII byte literal
+	value []byte // ASCII byte literal. Always item-owned or an immutable
+	// string alias (SetValues copies caller []byte, aliases strings); never
+	// aliases a caller-mutable buffer, never mutated in place. This ownership
+	// invariant is what makes ASCIIItem.Clone's value-share safe.
 	rawBytes []byte // Raw bytes for the item, if needed
 }
 
@@ -135,14 +138,18 @@ func (item *ASCIIItem) Values() any {
 // and also stored within the item for later retrieval.
 func (item *ASCIIItem) SetValues(values ...any) error {
 	item.resetError()
+	item.rawBytes = nil // invalidate cached serialization
 
 	var itemValue []byte
-	if len(values) == 1 { // avoid memory allocation if there is only one value
+	if len(values) == 1 {
 		switch val := values[0].(type) {
 		case string:
+			// StringToBytes aliases the immutable string backing; safe to share.
 			itemValue = StringToBytes(val)
 		case []byte:
-			itemValue = val
+			// Copy caller-owned bytes so value never aliases a buffer the caller
+			// may later mutate; this is what makes Clone's value-share safe.
+			itemValue = append([]byte(nil), val...)
 		default:
 			err := NewItemErrorWithMsg("the value is not a string or []byte")
 			item.setError(err)
@@ -313,12 +320,13 @@ func (item *ASCIIItem) toSMLFast() string {
 
 // Clone creates a deep copy of the ASCIIItem.
 //
-// This method implements the Item.Clone() interface. It returns a new ASCIIItem
-// with the same ASCII string value as the original item. Since strings are immutable in Go,
-// a simple copy of the `value` field is sufficient to create a deep copy.
-//
-// The `SetValues` method is assumed to create a new string when modifying the item's value,
-// ensuring that the cloned item remains independent of any future changes to the original.
+// This method implements the Item.Clone() interface. The value byte slice is
+// shared with the original, which is both safe and intentionally
+// zero-allocation: value is always item-owned or an immutable string alias
+// (SetValues copies caller-supplied []byte and aliases strings), is never
+// mutated in place, and is only ever replaced wholesale. Mutating either item
+// via SetValues swaps that item's own slice header and leaves the other
+// untouched, so original and clone are independent.
 func (item *ASCIIItem) Clone() Item {
 	return &ASCIIItem{value: item.value}
 }

--- a/secs2/binary.go
+++ b/secs2/binary.go
@@ -137,6 +137,7 @@ func (item *BinaryItem) Values() any {
 // the error is returned and also stored within the item for later retrieval.
 func (item *BinaryItem) SetValues(values ...any) error {
 	item.resetError()
+	item.rawBytes = nil // invalidate cached serialization
 
 	item.values = item.values[:0]
 

--- a/secs2/boolean.go
+++ b/secs2/boolean.go
@@ -115,6 +115,7 @@ func (item *BooleanItem) Values() any {
 // the error is returned and also stored within the item for later retrieval.
 func (item *BooleanItem) SetValues(values ...any) error {
 	item.resetError()
+	item.rawBytes = nil // invalidate cached serialization
 
 	item.values = item.values[:0]
 

--- a/secs2/clone_deep_test.go
+++ b/secs2/clone_deep_test.go
@@ -1,0 +1,129 @@
+package secs2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A clone's child must be an independent object: mutating it must not affect
+// the original. Pre-fix ListItem.Clone is shallow (shares child pointers), so
+// this fails.
+func TestListItem_Clone_DeepIndependence(t *testing.T) {
+	require := require.New(t)
+
+	orig := L(A("alpha"), A("beta"))
+	clone := orig.Clone()
+
+	cloneChild, err := clone.Get(0)
+	require.NoError(err)
+	require.NoError(cloneChild.SetValues("MUTATED"))
+
+	origChild, err := orig.Get(0)
+	require.NoError(err)
+	got, err := origChild.ToASCII()
+	require.NoError(err)
+	require.Equal("alpha", got, "mutating clone child must not change original")
+
+	// And the clone actually took the mutation.
+	gotClone, err := cloneChild.ToASCII()
+	require.NoError(err)
+	require.Equal("MUTATED", gotClone)
+}
+
+// Independence must hold recursively through nested lists.
+func TestListItem_Clone_NestedIndependence(t *testing.T) {
+	require := require.New(t)
+
+	orig := L(L(A("deep")))
+	clone := orig.Clone()
+
+	innerClone, err := clone.Get(0)
+	require.NoError(err)
+	deepClone, err := innerClone.Get(0)
+	require.NoError(err)
+	require.NoError(deepClone.SetValues("X"))
+
+	innerOrig, err := orig.Get(0)
+	require.NoError(err)
+	deepOrig, err := innerOrig.Get(0)
+	require.NoError(err)
+	got, err := deepOrig.ToASCII()
+	require.NoError(err)
+	require.Equal("deep", got, "nested clone child must be independent")
+}
+
+// SetValues([]byte) must not retain the caller's buffer: mutating the caller's
+// slice afterward must not change the item. Fails pre-fix (the single-value
+// []byte branch aliases the caller slice).
+func TestASCIIItem_SetValues_CopiesByteInput(t *testing.T) {
+	require := require.New(t)
+
+	buf := []byte("abc")
+	item := A("")
+	require.NoError(item.SetValues(buf))
+
+	buf[0] = 'X' // mutate the caller's buffer
+
+	got, err := item.ToASCII()
+	require.NoError(err)
+	require.Equal("abc", got, "item must not alias the caller's []byte")
+}
+
+// A clone of an ASCII item built from []byte must be independent of the
+// caller's buffer (covers the Clone backing-share). Fails pre-fix.
+func TestASCIIItem_Clone_IndependentFromCallerBytes(t *testing.T) {
+	require := require.New(t)
+
+	buf := []byte("abc")
+	orig := A("")
+	require.NoError(orig.SetValues(buf))
+	clone := orig.Clone()
+
+	buf[0] = 'X' // mutate the caller's buffer
+
+	gotOrig, err := orig.ToASCII()
+	require.NoError(err)
+	require.Equal("abc", gotOrig)
+
+	gotClone, err := clone.ToASCII()
+	require.NoError(err)
+	require.Equal("abc", gotClone, "clone must not alias the caller's []byte")
+}
+
+// Same hazard reached through a ListItem deep clone with a []byte-built child.
+func TestListItem_Clone_IndependentFromCallerBytes(t *testing.T) {
+	require := require.New(t)
+
+	buf := []byte("abc")
+	child := A("")
+	require.NoError(child.SetValues(buf))
+	orig := L(child)
+	clone := orig.Clone()
+
+	buf[0] = 'X'
+
+	cloneChild, err := clone.Get(0)
+	require.NoError(err)
+	got, err := cloneChild.ToASCII()
+	require.NoError(err)
+	require.Equal("abc", got)
+}
+
+// String-built items stay independent under SetValues (regression guard for the
+// branch we did NOT change).
+func TestASCIIItem_Clone_IndependentUnderSetValues(t *testing.T) {
+	require := require.New(t)
+
+	orig := A("hello")
+	clone := orig.Clone()
+	require.NoError(clone.SetValues("world"))
+
+	gotOrig, err := orig.ToASCII()
+	require.NoError(err)
+	require.Equal("hello", gotOrig)
+
+	gotClone, err := clone.ToASCII()
+	require.NoError(err)
+	require.Equal("world", gotClone)
+}

--- a/secs2/list.go
+++ b/secs2/list.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/arloliu/go-secs/internal/util"
 )
 
 // ListItem is a immutable data type that represents a list data in a SECS-II message.
@@ -162,6 +160,7 @@ func (item *ListItem) Values() any {
 // the error is returned and also stored within the item for later retrieval.
 func (item *ListItem) SetValues(values ...any) error {
 	item.resetError()
+	item.rawBytes = nil // invalidate cached serialization
 
 	dataBytes, _ := getDataByteLength(ListType, len(values))
 	if dataBytes > MaxByteSize {
@@ -226,14 +225,24 @@ func (item *ListItem) ToSML() string {
 	return item.formatSML(0)
 }
 
-// Clone creates a shadow copy of the ListItem.
+// Clone creates a deep copy of the ListItem.
 //
-// This method implements the Item.Clone() interface. It returns a new
-// ListItem with a shadow copy of the items.
-//
-// Note: It's unsafe to use the new cloned data for immutable operations.
+// This method implements the Item.Clone() interface. It allocates a new,
+// pre-sized values slice and recursively clones every child, so the returned
+// ListItem shares no mutable state with the original. This makes a cloned list
+// safe to serialize concurrently with its source (e.g. fan-out to multiple
+// DataMessageHandler goroutines): each clone owns its own child Items and hence
+// its own lazily-populated rawBytes cache, so concurrent ToBytes calls touch
+// disjoint memory.
 func (item *ListItem) Clone() Item {
-	return &ListItem{values: util.CloneSlice(item.values, 0)}
+	cloned := make([]Item, len(item.values))
+	for i, child := range item.values {
+		if child != nil {
+			cloned[i] = child.Clone()
+		}
+	}
+
+	return &ListItem{values: cloned}
 }
 
 func (item *ListItem) Error() error {

--- a/secs2/setvalues_cache_test.go
+++ b/secs2/setvalues_cache_test.go
@@ -1,0 +1,61 @@
+package secs2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// SetValues must invalidate the lazily-built rawBytes serialization cache.
+// Without invalidation, ToBytes() after a SetValues() on an already-serialized
+// item returns the stale bytes of the previous value. Covers the four cached
+// item types (ASCII, Binary, Boolean, List).
+func TestSetValues_InvalidatesRawBytesCache(t *testing.T) {
+	tests := []struct {
+		name   string
+		build  func() Item
+		mutate func(Item) error
+		fresh  func() Item // an item constructed directly with the mutated value
+	}{
+		{
+			name:   "ascii",
+			build:  func() Item { return A("hello") },
+			mutate: func(it Item) error { return it.SetValues("world") },
+			fresh:  func() Item { return A("world") },
+		},
+		{
+			name:   "binary",
+			build:  func() Item { return B(1, 2, 3) },
+			mutate: func(it Item) error { return it.SetValues(9, 9) },
+			fresh:  func() Item { return B(9, 9) },
+		},
+		{
+			name:   "boolean",
+			build:  func() Item { return BOOLEAN(true) },
+			mutate: func(it Item) error { return it.SetValues(false) },
+			fresh:  func() Item { return BOOLEAN(false) },
+		},
+		{
+			name:   "list",
+			build:  func() Item { return L(A("x")) },
+			mutate: func(it Item) error { return it.SetValues(A("y"), A("z")) },
+			fresh:  func() Item { return L(A("y"), A("z")) },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			it := tc.build()
+			_ = it.ToBytes() // populate the rawBytes cache
+
+			require.NoError(tc.mutate(it))
+
+			// After mutation, ToBytes must reflect the new value, not the cached
+			// serialization of the old one.
+			require.Equal(tc.fresh().ToBytes(), it.ToBytes(),
+				"ToBytes after SetValues returned a stale cached serialization")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This branch closes a real data race on the concurrent fan-out path and adds two opt-in clone capabilities to `hsms.DataMessage`, plus a decoder gap fix.

### Fixed (correctness)
- **`secs2.ListItem.Clone` was shallow** — it shared child items with the original, so a cloned message and its source serialized concurrently (the multi-handler / broadcast path) raced on each child's lazily-populated `rawBytes`. It is now a recursive deep copy; clones are fully independent. The prior `Clone` godoc ("shares no mutable state", "safe to serialize concurrently") was false for list payloads until this fix.
- **`ASCIIItem.SetValues([]byte)` aliased the caller's slice** — it now copies at ingestion, which lets `ASCIIItem.Clone` keep sharing its now-owned/immutable backing at zero allocation (the cost moved to ingestion, not clone).
- **`SetValues` left a stale serialization cache** — ASCII/Binary/Boolean/List `SetValues` now invalidate `rawBytes`, so `ToBytes` after a mutation reflects the new values.
- **JIS8 / localized-string decode** — `DecodeSECS2Item` / `DecodeHSMSMessage` previously returned "invalid format" for JIS8 (0o21) and localized-string (0o22) items; both decode correctly now.

### Added (API)
- **`DataMessage.CloneCodec()`** — independent deep copy typed only as `encoding.BinaryMarshaler`/`BinaryUnmarshaler`, so external code can obtain a fan-out-safe copy through a self-declared capability interface without importing this package. Thin wrapper over `Clone`.
- **`DataMessage.SnapshotForRelay()`** — opt-in, relay-optimized snapshot. Serializes the message once and serves those bytes from `ToBytes` without re-encoding; decodes the item structure lazily only on structural access.

## SnapshotForRelay: measured trade-off (not a free win)

Like-for-like single-consumer benchmarks (medians of 5×300 runs, Ryzen 9 9950X3D):

| Payload | Relay: `Clone`→`ToBytes` | Relay: `SnapshotForRelay`→`ToBytes` | Structural: `Clone`→`Item` | Structural: `SnapshotForRelay`→`Item` |
|---|---|---|---|---|
| ascii64k | 26889 ns / 12 allocs | **5883 / 2** (4.6×) | 148 / 6 | 5076 / 8 (34× slower) |
| list1000 | 75293 / 2024 | **669 / 5** (112×) | 29921 / 1005 | 64698 / 1012 (2.2× slower) |
| nested256 | 24061 / 1025 | **119 / 3** (200×) | 11529 / 429 | 26949 / 602 (2.3× slower) |

- **Relay (serialize-and-forward) consumer:** big win even at N=1 — the gain is intrinsic per clone (skips structural deep copy + re-encode), not amortized.
- **Structural consumer (accesses items):** `SnapshotForRelay` is *slower* than `Clone` (serialize-at-clone + lazy-decode-at-access). So `Clone` stays the right choice for structural consumers, which is why this is kept opt-in rather than made the default.

## Reviewer notes
- `SnapshotForRelay` returns the unexported snapshot type as `HSMSMessage`, **not** `*DataMessage`, and is **not** on the `HSMSMessage` interface. The in-process handler fan-out (`hsmsss/session.go`, `secs1/session.go`) type-asserts to `*DataMessage` and its handlers do structural access, so it deliberately keeps using `Clone`. **`SnapshotForRelay` therefore has no production caller yet** — it is opt-in infrastructure for a future serialize-and-forward relay/gateway path.
- `Clone` / `CloneCodec` / the `DataMessage` struct (48 bytes) are unchanged.

## Validation
- `make check` (golangci-lint + vet): 0 issues.
- `make test` (`-short -race`, all packages incl. hsmsss/secs1 integration): green.
- Independent review (Codex, xhigh) of the implementation: verdict **merge**, no P0/P1/P2.

## Commits (by scope)
1. `fix(secs2)`: deep-copy `Item.Clone` + serialization-cache correctness
2. `feat(hsms)`: `CloneCodec`, `SnapshotForRelay`, JIS8/localized decode
3. `docs`: CHANGELOG