### PR TITLE
fix: harden the public contract surface and cut v2.4.1

### DIFF
--- a/.knowledges/hsms/transition-cause-injection-sites.md
+++ b/.knowledges/hsms/transition-cause-injection-sites.md
@@ -26,6 +26,7 @@ sources:
   - {resource: hsmsss/transport_passive.go, digest: sha256:f5c2688db6585682, revision: 71a7afe}
   - {resource: hsmsss/transport_procedures.go, digest: sha256:232ee3127c6ae84b, revision: 0b40043}
   - {resource: hsmsss/transport_recv.go, digest: sha256:1b3b40dfd747daaf, revision: 2942595}
+  - {resource: secs1/transport.go, digest: sha256:05f8cb504e3bbeef, revision: 8bb9188}
 ---
 
 # What it does
@@ -293,7 +294,7 @@ see `hsmsss.causeLog.waitBringUp`, which tolerates both shapes.
 - the synchronous-commit fence: `hsms/connection.go` → `genGate`;
   `hsms/connection_lifecycle.go` → `commitGate`, `publishSocket`, `commitTCPUp`, `genCapability`;
   `hsms/epoch.go` → `epoch.ended`, `epoch.markEnded`;
-  `hsms/supervisor.go` → `commitFrom` and the three `Commit*FromGeneration` methods;
+  `hsms/supervisor.go` → `commitFrom`, `CommitConnectedFromGeneration`, `CommitSelectedFromGeneration`, `CommitSelectLostFromGeneration`;
   `hsms/connection_runtime.go` → `commitSelectAccepted`, `commitSelectLost`
 - transport capability: `hsmsss/transport_control.go` → `causeRuntime`, `genRuntime`,
   `transport.tcpDown`, `transport.t7Expired`, `transport.tcpUp`, `transport.commitSelected`, `transport.selectLost`;

--- a/.knowledges/index.md
+++ b/.knowledges/index.md
@@ -1,6 +1,6 @@
 ---
 okf_version: "0.2"
-swept_at: 3660aa4
+swept_at: 6cf2b49
 ---
 
 # go-secs memex

--- a/.knowledges/log.md
+++ b/.knowledges/log.md
@@ -1,5 +1,16 @@
 # Log
 
+## 2026-08-14
+* **Update**: [Where a TransitionCause is chosen](/hsms/transition-cause-injection-sites.md) refreshed the `secs1/transport.go` digest and revision after a semantic-linefeed-only comment change;
+  mechanic prose, generated metadata, and trust status remain unchanged.
+* **Update**: [Where a TransitionCause is chosen](/hsms/transition-cause-injection-sites.md) now cites `secs1/transport.go`, which its `causeRuntime` pointer already named;
+  the body remains unchanged.
+* **Update**: [Parser input bounds](/sml/prealloc-bound.md) refreshed the parser allocation-test digest and revision after strict ASCII coverage was strengthened;
+  prose and generated metadata remain unchanged because the documented mechanic did not change.
+* **Update**: [Parser input bounds](/sml/prealloc-bound.md) now records the 64-element initial-capacity ceiling that prevents unrelated trailing input from amplifying parser preallocation;
+  digests and revisions were refreshed.
+  The entry remains draft pending independent verification.
+
 ## 2026-08-13
 * **Update**: [Where a TransitionCause is chosen](/hsms/transition-cause-injection-sites.md) resynced after the Select-failure classification fix (`5a0ec1b`): the active Select procedure is the one site whose cause is not a constant, because its reply registry can return a `*hsms.RejectError` (peer refused — not an I/O fault), a bare `ErrT6Timeout` (peer never answered), or a transport error; a correlated response of the wrong TYPE also reports `CauseSelectRejected`, with the refusal-versus-wrong-frame distinction kept in the error value rather than the cause.
 * **Creation**: [Where a TransitionCause is chosen, and why one transition can swallow another's cause](/hsms/transition-cause-injection-sites.md) records the full injection-site to cause map behind `SubscribeLifecycle`; why the cause is data on `fsmCommand` rather than a function of the state pair; why the transports name it through a package-local `causeRuntime` capability instead of a widened `TransportRuntime`, so a bare `TCPDown` reports `CauseUnknown` rather than a guess; and the three ways a cause never reaches a subscriber (dedup on the state entered, drop-oldest coalescing, and the bring-up pair collapsing when the select commit outruns the TCP-up event); born draft.

--- a/.knowledges/sml/prealloc-bound.md
+++ b/.knowledges/sml/prealloc-bound.md
@@ -4,12 +4,12 @@ title: Parser input bounds
 description: How the SML parser bounds allocation and recursion on attacker-controlled input.
 tags: [sml, parser, security, allocation, recursion]
 status: draft
-generated: {by: "claude/fable-5", at: 2026-08-12T10:45:49Z}
+generated: {by: "openai/gpt-5.6-sol", at: 2026-08-14T08:11:01Z}
 sources:
-  - {resource: sml/parser.go, digest: sha256:d56c5287e7e299b9, revision: 5cf7389}
-  - {resource: sml/parser_depth_test.go, digest: sha256:3230469c3aa4f0fe, revision: 5cf7389}
-  - {resource: secs2/decode.go, digest: sha256:8ca1e530a8d03c4a, revision: 5cf7389}
-  - {resource: sml/parser_dos_test.go, digest: sha256:51c56d2ddbd8b51d, revision: 5cf7389}
+  - {resource: sml/parser.go, digest: sha256:6a166a179414e02e, revision: f56c67a}
+  - {resource: sml/parser_depth_test.go, digest: sha256:3230469c3aa4f0fe, revision: f56c67a}
+  - {resource: secs2/decode.go, digest: sha256:8ca1e530a8d03c4a, revision: f56c67a}
+  - {resource: sml/parser_dos_test.go, digest: sha256:3465ac02e29b67c0, revision: 6cf2b49}
 ---
 
 # What it does
@@ -18,7 +18,7 @@ The parser used that count directly to size the buffer it preallocated.
 `sml/doc.go` documents the public contract but says nothing about this.
 The count is read off attacker-controlled text and bounded only by `math.MaxInt32`.
 A 29-byte message like `<U1[2000000000] 1 2 3>` therefore drove a multi-gigabyte allocation before any payload byte was inspected.
-The parser now clamps that preallocation hint,
+The parser now caps that preallocation hint at 64 elements,
 and bounds list nesting by the same constant the wire decoder uses.
 
 # How it works
@@ -28,7 +28,9 @@ The six slice-building parsers preallocate through `capHint(size, len(p.data))` 
 and `parseASCIIStrict` grows its `strings.Builder` through the same helper.
 `p.data` is the unconsumed remainder of the input.
 Every element the parser can still produce consumes at least one input byte,
-so `len(p.data)` is a sound upper bound and `capHint` returns `min(size, len(p.data))`.
+so `len(p.data)` is a sound local upper bound.
+`capHint` returns `min(size, len(p.data), 64)`,
+preventing unrelated trailing input from amplifying the initial allocation.
 The clamp caps only initial capacity.
 `append` and `Builder` growth still reach the true size,
 so a message whose declared count matches its payload is unaffected.
@@ -36,7 +38,7 @@ so a message whose declared count matches its payload is unaffected.
 Note the size token is a *hint only*, not a contract the parser enforces.
 `parseItem` discards the minimum,
 and no body parser reconciles the declared count against the number of values actually parsed.
-That is why the bound must come from the remaining input rather than from validating the token.
+That is why the hint must be bounded independently rather than relying on validation of the token.
 
 The size token is not the only attacker-controlled length in this area.
 `parseASCIIStrict` also reads unquoted numeric tokens,
@@ -59,6 +61,8 @@ a 195 KB token copied its way to roughly 19 GB before `ParseUint` ever rejected 
   Strict-mode ASCII was exactly this, reaching ~1.9 GB from a 25-byte input until its `Builder.Grow` was clamped too.
 - `TestParse_HugeDeclaredSizeDoesNotPrealloc` guards all seven paths,
   asserting that a huge declared count keeps allocation bounded.
+- `TestParse_PaddingDoesNotAmplifyPreallocation` guards against a large suffix inflating the remaining-input bound,
+  asserting that list, numeric, and ASCII inputs stay below the allocation ceiling.
 - `TestParseStrict_LongNumericTokenDoesNotCopyQuadratically` guards the numeric-token path,
   where the cost was quadratic in the token length rather than driven by the size token.
 - `TestParse_ListDepthMatchesWireDecoder` pins the nesting ceiling to the decoder's,
@@ -78,5 +82,5 @@ a 195 KB token copied its way to roughly 19 GB before `ParseUint` ever rejected 
 - clamped slice parsers: `sml/parser.go` → `parseList`, `parseBoolean`, `parseBinary`, `parseFloat`, `parseInt`, `parseUint`
 - clamped builder and sliced numeric token: `sml/parser.go` → `parseASCIIStrict`
 - nesting bound: `sml/parser.go` → `parseList`; the shared constant is `secs2/decode.go` → `MaxListDepth`
-- regression guards: `sml/parser_dos_test.go` → `TestParse_HugeDeclaredSizeDoesNotPrealloc`, `TestParseStrict_LongNumericTokenDoesNotCopyQuadratically`
+- regression guards: `sml/parser_dos_test.go` → `TestParse_HugeDeclaredSizeDoesNotPrealloc`, `TestParse_PaddingDoesNotAmplifyPreallocation`, `TestParseStrict_LongNumericTokenDoesNotCopyQuadratically`
 - nesting guard: `sml/parser_depth_test.go` → `TestParse_ListDepthMatchesWireDecoder`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.1] - 2026-08-15
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- `sml`: programmatic item trees now stop at the same nesting depth as parser and wire decoder input,
+  and padded trailing input no longer amplifies parser preallocation.
+
+### Fixed
+
+- Public constructors, options, cursor traversal, list traversal, reply helpers, and SML logging helpers return errors or diagnostics for nil-like inputs instead of panicking.
+- Invalid SECS-II lists no longer emit a child count that disagrees with their wire payload.
+- Strict SML output escapes `>` and single-line item colons no longer alter header parsing.
+- SECS-I reports EOF and socket failures as I/O errors rather than T1/T2 expiry,
+  and its core deadline hooks no longer alter line-engine socket deadlines.
+- HSMS-SS inbound control tracing follows live logger and trace updates.
+
+### Known follow-ups
+
+- A dribbling SECS-I peer can keep malformed-frame draining active until disconnect.
+- Large legal SECS-II lists can expand to a much larger decoded object graph.
+- Framing protocol failures still report the existing `CauseIOError` lifecycle cause.
+
 ## [2.4.0] - 2026-08-14
 
 Consumer ergonomics and observability:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Public constructors, options, cursor traversal, list traversal, reply helpers, and SML logging helpers return errors or diagnostics for nil-like inputs instead of panicking.
+- Public constructors, options, cursor traversal, list traversal, send and reply helpers, and SML logging helpers return errors or diagnostics for nil-like inputs instead of panicking.
 - Invalid SECS-II lists no longer emit a child count that disagrees with their wire payload.
 - Strict SML output escapes `>` and single-line item colons no longer alter header parsing.
 - SECS-I reports EOF and socket failures as I/O errors rather than T1/T2 expiry,
@@ -27,8 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Large legal SECS-II lists can expand to a much larger decoded object graph.
   SML input that declares counts it never supplies preallocates several times what honest input needs.
 - Framing protocol failures still report the existing `CauseIOError` lifecycle cause.
-- Typed-nil guards at the `secs2` item boundary add roughly 3 ns per cursor hop and per `Equal` comparison.
-  Allocations are unchanged.
+- Typed-nil and zero-value guards at the `secs2` item boundary cost a few nanoseconds each.
+  They apply at every cursor hop, every terminal accessor, and every `Equal` comparison.
+  A two-hop cursor extraction takes about 9 ns longer than in v2.4.0, with allocations unchanged.
 
 ## [2.4.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A dribbling SECS-I peer can keep malformed-frame draining active until disconnect.
 - Large legal SECS-II lists can expand to a much larger decoded object graph.
+  SML input that declares counts it never supplies preallocates several times what honest input needs.
 - Framing protocol failures still report the existing `CauseIOError` lifecycle cause.
+- Typed-nil guards at the `secs2` item boundary add roughly 3 ns per cursor hop and per `Equal` comparison.
+  Allocations are unchanged.
 
 ## [2.4.0] - 2026-08-14
 

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,8 @@ STRESS_COUNT   ?= 10
 FUZZ_TIME      ?= 30s
 GO_TEST_P      ?= $(shell nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8)
 
-ALL_SRC        := $(shell find . -name "*.go")
-ALL_SRC        += go.mod
-TEST_DIRS      := $(sort $(dir $(filter %_test.go,$(ALL_SRC))))
+# go list stays within the root module and skips hidden directories.
+TEST_DIRS      := $(sort $(patsubst $(CURDIR),./,$(patsubst $(CURDIR)/%,./%/,$(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.Dir}}{{end}}' ./...))))
 LATEST_GIT_TAG := $(shell git describe --tags --abbrev=0 2>/dev/null)
 MODULE_PATH    := $(shell go list -m 2>/dev/null)
 

--- a/hsms/connection_config.go
+++ b/hsms/connection_config.go
@@ -104,6 +104,11 @@ func (c *ConnectionConfig) apply(opts ...ConnOption) error {
 	var errs []error
 
 	for _, opt := range opts {
+		if opt == nil {
+			errs = append(errs, errors.New("hsms: option must not be nil"))
+			continue
+		}
+
 		if err := opt(&scratch); err != nil {
 			errs = append(errs, err)
 		}

--- a/hsms/connection_runtime.go
+++ b/hsms/connection_runtime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/arloliu/go-secs/v2/gem"
+	"github.com/arloliu/go-secs/v2/logger"
 )
 
 // RouteData delivers an inbound data message to the session fan-out (TransportRuntime).
@@ -117,6 +118,13 @@ func (c *connection) T7Expired() {
 // A gen of 0 skips the match.
 func (c *connection) T7ExpiredFromGeneration(gen uint64) {
 	c.injectT7Expiry(gen)
+}
+
+// TraceConfig returns trace enablement and its logger from one live configuration snapshot.
+func (c *connection) TraceConfig() (bool, logger.Logger) {
+	cfg := c.cfg.Load()
+
+	return cfg.traceTraffic, cfg.logger
 }
 
 // injectT7Expiry is the shared body of the T7 dwell-expiry back-channel.

--- a/hsms/connection_runtime_test.go
+++ b/hsms/connection_runtime_test.go
@@ -431,6 +431,20 @@ func TestDeliverOwnedFrame_TraceTraffic_LogsDecodeFailure(t *testing.T) {
 	require.Contains(t, keyvals, hexDump(garbage), "the logged payload must carry the raw frame hex dump")
 }
 
+func TestConnection_TraceConfig_UsesLiveSnapshot(t *testing.T) {
+	conn, core := newTestConn(t)
+	newLogger := loggertest.NewMockLogger()
+	err := conn.UpdateConfigOptions(
+		WithTraceTraffic(true),
+		WithLogger(newLogger),
+	)
+	require.NoError(t, err)
+
+	enabled, gotLogger := core.TraceConfig()
+	require.True(t, enabled)
+	require.Same(t, newLogger, gotLogger)
+}
+
 // TestDeliverOwnedFrame_DecodeErrCount proves an inbound frame that fails to decode increments
 // DecodeErrCount exactly once and does NOT increment DataMsgRecvCount (the receive chokepoint is
 // only reached after a successful decode).

--- a/hsms/connection_test.go
+++ b/hsms/connection_test.go
@@ -2,6 +2,7 @@ package hsms
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -85,6 +86,21 @@ func TestConnection_UpdateConfigOptions_Transactional(t *testing.T) {
 	require.NoError(t, conn.UpdateConfigOptions(WithT3(3*time.Second), WithSessionID(7)))
 	require.Equal(t, 3*time.Second, c.cfg.Load().timers.T3)
 	require.Equal(t, uint16(7), c.cfg.Load().sessionID)
+}
+
+func TestConnection_UpdateConfigOptions_NilOption(t *testing.T) {
+	conn, c := newTestConn(t)
+	origT3 := c.cfg.Load().timers.T3
+	siblingErr := errors.New("sibling option failed")
+
+	err := conn.UpdateConfigOptions(
+		WithT3(2*time.Second),
+		nil,
+		func(*ConnectionConfig) error { return siblingErr },
+	)
+	require.ErrorContains(t, err, "option must not be nil")
+	require.ErrorIs(t, err, siblingErr)
+	require.Equal(t, origT3, c.cfg.Load().timers.T3, "valid option must not commit when nil is in the batch")
 }
 
 // TestConnection_DoneBeforeOpenIsClosed verifies Done() returns an already-closed channel

--- a/hsms/data_msg.go
+++ b/hsms/data_msg.go
@@ -340,7 +340,7 @@ func NewDataMessage(stream, function uint8, replyExpected bool, sessionID uint16
 
 	// A nil-like item is treated as an empty body,
 	// mirroring the decode path where an empty (zero-length) body is legal and yields secs2.NewEmptyItem.
-	if isNilItem(item) {
+	if isNilValue(item) {
 		item = secs2.NewEmptyItem()
 	}
 
@@ -408,15 +408,20 @@ func NewDataMessageFromHeader(header [10]byte, item secs2.Item) (*DataMessage, e
 // Internal helpers
 // ────────────────────────────────────────────────────────────────
 
-func isNilItem(item secs2.Item) bool {
-	if item == nil {
+// isNilValue reports whether v is a nil interface value,
+// or an interface holding a typed nil.
+//
+// Passing an interface to an `any` parameter preserves its dynamic type,
+// so this is correct for any interface the package needs to guard.
+func isNilValue(v any) bool {
+	if v == nil {
 		return true
 	}
 
-	v := reflect.ValueOf(item)
-	switch v.Kind() { //nolint:exhaustive // only nil-capable kinds may call Value.IsNil
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() { //nolint:exhaustive // only nil-capable kinds may call Value.IsNil
 	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
-		return v.IsNil()
+		return rv.IsNil()
 	default:
 		return false
 	}

--- a/hsms/data_msg.go
+++ b/hsms/data_msg.go
@@ -3,6 +3,7 @@ package hsms
 import (
 	"encoding/binary"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/arloliu/go-secs/v2/internal/framecodec"
@@ -322,8 +323,8 @@ func (b *DataMessageBuilder) Build() (*DataMessage, error) {
 
 // NewDataMessage creates an immutable HSMS data message.
 //
-// A nil item is treated as an empty body ([secs2.NewEmptyItem]), consistent with the decode path
-// where a zero-length body is legal.
+// A nil or typed-nil item is treated as an empty body ([secs2.NewEmptyItem]),
+// consistent with the decode path where a zero-length body is legal.
 //
 // Q3 validation (SEMI E37 §8.3.3.3) is performed before construction:
 //
@@ -337,10 +338,9 @@ func NewDataMessage(stream, function uint8, replyExpected bool, sessionID uint16
 		return nil, ErrInvalidStreamCode
 	}
 
-	// A nil item is treated as an empty body, mirroring the decode path where an
-	// empty (zero-length) body is legal and yields secs2.NewEmptyItem. This avoids
-	// a nil-interface panic in the item.Error() gate below.
-	if item == nil {
+	// A nil-like item is treated as an empty body,
+	// mirroring the decode path where an empty (zero-length) body is legal and yields secs2.NewEmptyItem.
+	if isNilItem(item) {
 		item = secs2.NewEmptyItem()
 	}
 
@@ -407,6 +407,20 @@ func NewDataMessageFromHeader(header [10]byte, item secs2.Item) (*DataMessage, e
 // ────────────────────────────────────────────────────────────────
 // Internal helpers
 // ────────────────────────────────────────────────────────────────
+
+func isNilItem(item secs2.Item) bool {
+	if item == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(item)
+	switch v.Kind() { //nolint:exhaustive // only nil-capable kinds may call Value.IsNil
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
 
 // decode is the payload for [decodeState].once.Do. For tree-path messages the
 // once is pre-fired during [NewDataMessage], so this function never executes for

--- a/hsms/data_msg_test.go
+++ b/hsms/data_msg_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type externalNilItem struct {
+	secs2.Item
+}
+
+var _ secs2.Item = (*externalNilItem)(nil)
+
 // ────────────────────────────────────────────────────────────────
 // Interface compile-time check
 // ────────────────────────────────────────────────────────────────
@@ -61,6 +67,11 @@ func TestNewDataMessage_EmptyItem(t *testing.T) {
 	assert.Equal(t, [4]byte{}, msg.SystemBytes())
 	assert.Equal(t, 0, msg.BodyLen())
 	assert.Nil(t, msg.DecodeErr())
+}
+
+func TestNewDataMessage_EmptyItemChild(t *testing.T) {
+	_, err := hsms.NewDataMessage(0, 1, true, 123, [4]byte{}, secs2.NewListItem(secs2.NewEmptyItem()))
+	require.Error(t, err)
 }
 
 // TestNewDataMessage_Vectors ports the three known encoding vectors from v1.
@@ -426,6 +437,39 @@ func TestNewDataMessage_NilItem(t *testing.T) {
 		require.NotNil(t, item)
 		assert.True(t, item.IsEmpty(), "nil item must decode to an empty item")
 	})
+}
+
+func TestNewDataMessage_TypedNilItem(t *testing.T) {
+	t.Parallel()
+
+	want, err := hsms.NewDataMessage(1, 13, true, 0, [4]byte{}, nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		item secs2.Item
+	}{
+		{name: "built-in pointer", item: (*secs2.ASCIIItem)(nil)},
+		{name: "external pointer", item: (*externalNilItem)(nil)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got *hsms.DataMessage
+			var gotErr error
+			require.NotPanics(t, func() {
+				got, gotErr = hsms.NewDataMessage(1, 13, true, 0, [4]byte{}, tt.item)
+			})
+			require.NoError(t, gotErr)
+			require.Equal(t, want.ToBytes(), got.ToBytes())
+
+			item, itemErr := got.Item()
+			require.NoError(t, itemErr)
+			require.True(t, item.IsEmpty())
+		})
+	}
 }
 
 // TestDataMessageBuilder_NilItem verifies that Derive().WithItem(nil).Build()

--- a/hsms/endpoint.go
+++ b/hsms/endpoint.go
@@ -114,6 +114,8 @@ type SECS2Endpoint interface {
 	// ReplyDataMessage sends a secondary data message in reply to a primary message.
 	//
 	// The reply reuses the primary message's System Bytes verbatim (E37 §8.2.6.9) and carries no W-bit.
+	//
+	// Returns ErrNilMessage if primary is nil.
 	ReplyDataMessage(ctx context.Context, primary *DataMessage, item secs2.Item) error
 
 	// AddDataMessageHandler appends one or more inbound data message handlers.

--- a/hsms/endpoint.go
+++ b/hsms/endpoint.go
@@ -63,6 +63,8 @@ type SECS2Endpoint interface {
 	//
 	// msg's function must be odd (SEMI E5 §7.2); an even function returns ErrEvenFunctionPrimary without sending anything.
 	//
+	// Returns ErrNilMessage if msg is nil.
+	//
 	// Returns the reply DataMessage on success.
 	SendSECS2Message(ctx context.Context, msg secs2.SECS2Message) (*DataMessage, error)
 

--- a/hsms/endpoint.go
+++ b/hsms/endpoint.go
@@ -63,7 +63,7 @@ type SECS2Endpoint interface {
 	//
 	// msg's function must be odd (SEMI E5 §7.2); an even function returns ErrEvenFunctionPrimary without sending anything.
 	//
-	// Returns ErrNilMessage if msg is nil.
+	// Returns ErrNilMessage if msg is nil or typed-nil.
 	//
 	// Returns the reply DataMessage on success.
 	SendSECS2Message(ctx context.Context, msg secs2.SECS2Message) (*DataMessage, error)

--- a/hsms/errors.go
+++ b/hsms/errors.go
@@ -117,7 +117,7 @@ var (
 	// even though — unlike ErrT3Timeout/ErrT6Timeout — that expiry does not make a retry worthwhile.
 	ErrCloseTimeout = errors.New("hsms: close timeout (tasks still live)")
 
-	// ErrNilMessage indicates ForwardDataMessage or ForwardDataMessageAsync was called with a nil message.
+	// ErrNilMessage indicates ReplyDataMessage, ForwardDataMessage, or ForwardDataMessageAsync was called with a nil message.
 	//
 	// Classification: IsTransient and IsTimeout both report false.
 	// This is a caller-side argument error, and the same nil argument fails on every retry.

--- a/hsms/errors.go
+++ b/hsms/errors.go
@@ -117,7 +117,8 @@ var (
 	// even though — unlike ErrT3Timeout/ErrT6Timeout — that expiry does not make a retry worthwhile.
 	ErrCloseTimeout = errors.New("hsms: close timeout (tasks still live)")
 
-	// ErrNilMessage indicates ReplyDataMessage, ForwardDataMessage, or ForwardDataMessageAsync was called with a nil message.
+	// ErrNilMessage indicates SendSECS2Message, ReplyDataMessage, ForwardDataMessage,
+	// or ForwardDataMessageAsync was called with a nil message.
 	//
 	// Classification: IsTransient and IsTimeout both report false.
 	// This is a caller-side argument error, and the same nil argument fails on every retry.

--- a/hsms/hsmstest/endpoint.go
+++ b/hsms/hsmstest/endpoint.go
@@ -265,6 +265,10 @@ func (f *FakeEndpoint) record(method string, stream, function byte, replyExpecte
 // primary.Stream() is already masked to <=127 and replyExpected is hardcoded false (so the
 // even-function W-bit check can never fire here).
 func (f *FakeEndpoint) recordReply(primary *hsms.DataMessage, item secs2.Item) error {
+	if primary == nil {
+		return hsms.ErrNilMessage
+	}
+
 	msg, err := hsms.NewDataMessage(
 		primary.Stream(), primary.Function()+1, false,
 		f.sessionID, primary.SystemBytes(), item,
@@ -374,8 +378,9 @@ func (f *FakeEndpoint) SendSECS2Message(_ context.Context, msg secs2.SECS2Messag
 	return f.popScriptedReply()
 }
 
-// ReplyDataMessage records the reply. It never consults the reply script (a reply is not a
-// synchronous send awaiting a response).
+// ReplyDataMessage records the reply.
+// It never consults the reply script (a reply is not a synchronous send awaiting a response).
+// Returns hsms.ErrNilMessage if primary is nil, recording nothing, matching the real session.
 func (f *FakeEndpoint) ReplyDataMessage(_ context.Context, primary *hsms.DataMessage, item secs2.Item) error {
 	return f.recordReply(primary, item)
 }

--- a/hsms/hsmstest/endpoint.go
+++ b/hsms/hsmstest/endpoint.go
@@ -6,6 +6,7 @@ package hsmstest
 import (
 	"context"
 	"errors"
+	"reflect"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -221,6 +222,25 @@ func (f *FakeEndpoint) AddConnStateChangeHandler(handlers ...hsms.StateChangeHan
 	f.stateHandlers = append(f.stateHandlers, handlers...)
 }
 
+// isNilMessage reports whether msg is a nil interface value,
+// or an interface holding a typed nil.
+//
+// It mirrors the guard hsms.session.SendSECS2Message applies,
+// so the fake rejects the same inputs the real endpoint rejects.
+func isNilMessage(msg secs2.SECS2Message) bool {
+	if msg == nil {
+		return true
+	}
+
+	rv := reflect.ValueOf(msg)
+	switch rv.Kind() { //nolint:exhaustive // only nil-capable kinds may call Value.IsNil
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
 // record constructs the DataMessage via hsms.NewDataMessage and returns its error, if any,
 // BEFORE any side effect — no Sent() entry, no scripted-reply pop, no handler invocation
 // happens on error. This mirrors the real session methods, which all return a NewDataMessage
@@ -333,7 +353,12 @@ func (f *FakeEndpoint) SendDataMessageAsync(_ context.Context, stream, function 
 // implementable secs2.SECS2Message interface.
 // When the snapshotted WaitBit is false it returns
 // (nil, nil) without consulting the reply script; when true it pops the next scripted reply.
+// A nil or typed-nil msg returns hsms.ErrNilMessage without recording anything.
 func (f *FakeEndpoint) SendSECS2Message(_ context.Context, msg secs2.SECS2Message) (*hsms.DataMessage, error) {
+	if isNilMessage(msg) {
+		return nil, hsms.ErrNilMessage
+	}
+
 	stream, function, waitBit, item := msg.StreamCode(), msg.FunctionCode(), msg.WaitBit(), msg.Item()
 	if function%2 == 0 {
 		return nil, hsms.ErrEvenFunctionPrimary

--- a/hsms/hsmstest/endpoint_test.go
+++ b/hsms/hsmstest/endpoint_test.go
@@ -639,6 +639,41 @@ func TestFakeEndpoint_ForwardDataMessage_NilMessage(t *testing.T) {
 	assert.Empty(t, ep.Sent(), "a nil forward records nothing")
 }
 
+// TestFakeEndpoint_SendSECS2Message_RejectsNilMessage proves the fake's nil guard:
+// FakeEndpoint.SendSECS2Message rejects a nil interface value and a typed-nil *secs2.Message,
+// mirroring hsms.session.SendSECS2Message.
+// It returns hsms.ErrNilMessage without panicking and without recording anything.
+func TestFakeEndpoint_SendSECS2Message_RejectsNilMessage(t *testing.T) {
+	t.Parallel()
+
+	var nilTyped *secs2.Message
+
+	tests := []struct {
+		name string
+		msg  secs2.SECS2Message
+	}{
+		{name: "interface nil", msg: nil},
+		{name: "typed nil", msg: nilTyped},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ep := hsmstest.NewFakeEndpoint()
+
+			var got *hsms.DataMessage
+			var err error
+			require.NotPanics(t, func() {
+				got, err = ep.SendSECS2Message(context.Background(), tt.msg)
+			})
+			require.ErrorIs(t, err, hsms.ErrNilMessage)
+			assert.Nil(t, got)
+			assert.Empty(t, ep.Sent(), "a nil message must not be recorded")
+		})
+	}
+}
+
 // TestFakeEndpoint_ScriptReply_MalformedReplyMirrorsRealDecodeError guards that the fake mirrors
 // the real session's reply-path decode check: a scripted reply that frames but whose SECS-II body
 // fails to decode is surfaced as (msg, decodeErr), not a clean (msg, nil). Without this a consumer

--- a/hsms/hsmstest/endpoint_test.go
+++ b/hsms/hsmstest/endpoint_test.go
@@ -604,6 +604,22 @@ func TestFakeEndpoint_ReplyDataMessage_InvalidConstruction(t *testing.T) {
 	assert.Empty(t, ep.Sent())
 }
 
+// TestFakeEndpoint_ReplyDataMessage_RejectsNilPrimary proves the fake's nil guard:
+// FakeEndpoint.ReplyDataMessage rejects a nil primary, mirroring hsms.session.ReplyDataMessage.
+// It returns hsms.ErrNilMessage without panicking and without recording anything.
+func TestFakeEndpoint_ReplyDataMessage_RejectsNilPrimary(t *testing.T) {
+	t.Parallel()
+
+	ep := hsmstest.NewFakeEndpoint()
+
+	var err error
+	require.NotPanics(t, func() {
+		err = ep.ReplyDataMessage(context.Background(), nil, secs2.NewEmptyItem())
+	})
+	require.ErrorIs(t, err, hsms.ErrNilMessage)
+	assert.Empty(t, ep.Sent(), "a nil primary must not be recorded")
+}
+
 func TestFakeEndpoint_ForwardDataMessage_RecordsVerbatim(t *testing.T) {
 	t.Parallel()
 

--- a/hsms/session.go
+++ b/hsms/session.go
@@ -136,6 +136,8 @@ func (s *session) SendDataMessageAsync(ctx context.Context, stream, function byt
 // always a primary; msg's function must be odd (SEMI E5 §7.2), or this returns
 // ErrEvenFunctionPrimary without sending anything.
 //
+// Returns ErrNilMessage if msg is nil.
+//
 // Returns the reply DataMessage when the W-bit is set.
 func (s *session) SendSECS2Message(ctx context.Context, msg secs2.SECS2Message) (*DataMessage, error) {
 	if isNilValue(msg) {
@@ -209,6 +211,8 @@ func (s *session) ForwardDataMessageAsync(ctx context.Context, msg *DataMessage)
 //
 // The reply function is primary.Function()+1 (SECS-II secondary-function convention: primary is odd, reply is even), replyExpected is false,
 // and system bytes are taken verbatim from primary (E37 §8.2.6.9 — system bytes must match).
+//
+// Returns ErrNilMessage if primary is nil.
 // The message is enqueued via rt.SendAsync (no W-bit, no reply correlation needed).
 func (s *session) ReplyDataMessage(ctx context.Context, primary *DataMessage, item secs2.Item) error {
 	if primary == nil {

--- a/hsms/session.go
+++ b/hsms/session.go
@@ -138,6 +138,10 @@ func (s *session) SendDataMessageAsync(ctx context.Context, stream, function byt
 //
 // Returns the reply DataMessage when the W-bit is set.
 func (s *session) SendSECS2Message(ctx context.Context, msg secs2.SECS2Message) (*DataMessage, error) {
+	if isNilValue(msg) {
+		return nil, ErrNilMessage
+	}
+
 	// secs2.SECS2Message is externally implementable and carries no immutability
 	// guarantee, so every field is snapshotted once into a local before the guard
 	// runs; the guard and the construction below both read the same snapshot,

--- a/hsms/session.go
+++ b/hsms/session.go
@@ -207,6 +207,10 @@ func (s *session) ForwardDataMessageAsync(ctx context.Context, msg *DataMessage)
 // and system bytes are taken verbatim from primary (E37 §8.2.6.9 — system bytes must match).
 // The message is enqueued via rt.SendAsync (no W-bit, no reply correlation needed).
 func (s *session) ReplyDataMessage(ctx context.Context, primary *DataMessage, item secs2.Item) error {
+	if primary == nil {
+		return ErrNilMessage
+	}
+
 	dm, err := NewDataMessage(
 		primary.Stream(),
 		primary.Function()+1, // SECS-II secondary function = primary function + 1

--- a/hsms/session.go
+++ b/hsms/session.go
@@ -136,7 +136,7 @@ func (s *session) SendDataMessageAsync(ctx context.Context, stream, function byt
 // always a primary; msg's function must be odd (SEMI E5 §7.2), or this returns
 // ErrEvenFunctionPrimary without sending anything.
 //
-// Returns ErrNilMessage if msg is nil.
+// Returns ErrNilMessage if msg is nil or typed-nil.
 //
 // Returns the reply DataMessage when the W-bit is set.
 func (s *session) SendSECS2Message(ctx context.Context, msg secs2.SECS2Message) (*DataMessage, error) {

--- a/hsms/session_test.go
+++ b/hsms/session_test.go
@@ -376,6 +376,39 @@ func TestSession_SendDataMessageAsync_RejectsEvenFunctionPrimary(t *testing.T) {
 	require.False(t, asyncCalled, "a refused send must never reach SendAsync")
 }
 
+// TestSession_SendSECS2Message_RejectsNilMessage proves SendSECS2Message guards a nil message:
+// it rejects a nil interface value and a typed-nil *secs2.Message,
+// returning ErrNilMessage without panicking and without reaching WriteMessage.
+func TestSession_SendSECS2Message_RejectsNilMessage(t *testing.T) {
+	rt := newMockRuntime(t)
+	s := newSession(0xFFFF, rt, &sysBytesGen{})
+
+	var nilTyped *secs2.Message
+
+	tests := []struct {
+		name string
+		msg  secs2.SECS2Message
+	}{
+		{name: "interface nil", msg: nil},
+		{name: "typed nil", msg: nilTyped},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				dm, err := s.SendSECS2Message(t.Context(), tt.msg)
+				require.ErrorIs(t, err, ErrNilMessage)
+				require.Nil(t, dm)
+			})
+
+			rt.mu.Lock()
+			writeCalled := rt.writeCalled
+			rt.mu.Unlock()
+			require.False(t, writeCalled, "a nil message must never reach WriteMessage")
+		})
+	}
+}
+
 // TestSession_SendSECS2Message_RejectsEvenFunctionPrimary mirrors the odd-function guard for the
 // secs2.SECS2Message entry point.
 func TestSession_SendSECS2Message_RejectsEvenFunctionPrimary(t *testing.T) {

--- a/hsms/session_test.go
+++ b/hsms/session_test.go
@@ -468,6 +468,30 @@ func TestSession_ReplyDataMessage_AllowsEvenFunction(t *testing.T) {
 	require.Equal(t, uint8(2), dm.Function(), "reply function must be primary.Function()+1 (even)")
 }
 
+func TestSession_ReplyDataMessage_NilPrimary(t *testing.T) {
+	rt := newMockRuntime(t)
+	s := newSession(0xFFFF, rt, &sysBytesGen{})
+
+	err := s.ReplyDataMessage(t.Context(), nil, secs2.NewEmptyItem())
+	require.ErrorIs(t, err, ErrNilMessage)
+}
+
+func TestSession_ReplyDataMessage_Function255UsesFunction0(t *testing.T) {
+	rt := newMockRuntime(t)
+	s := newSession(0xFFFF, rt, &sysBytesGen{})
+	primary, err := NewDataMessage(1, 255, true, 0xFFFF, [4]byte{0, 0, 0, 1}, secs2.NewEmptyItem())
+	require.NoError(t, err)
+
+	require.NoError(t, s.ReplyDataMessage(t.Context(), primary, secs2.NewEmptyItem()))
+	rt.mu.Lock()
+	sent := rt.asyncMsg
+	rt.mu.Unlock()
+
+	dm, ok := sent.(*DataMessage)
+	require.True(t, ok)
+	require.Equal(t, uint8(0), dm.Function())
+}
+
 // TestSession_ForwardDataMessage_AllowsEvenFunction is the counter-assertion for the forward
 // path: ForwardDataMessage bypasses construction entirely and must forward an even-function
 // message verbatim.

--- a/hsmsss/config.go
+++ b/hsmsss/config.go
@@ -75,6 +75,11 @@ func (c *Config) apply(opts ...Option) error {
 	var errs []error
 
 	for _, opt := range opts {
+		if opt == nil {
+			errs = append(errs, errors.New("hsmsss: option must not be nil"))
+			continue
+		}
+
 		if err := opt(&scratch); err != nil {
 			errs = append(errs, err)
 		}
@@ -257,6 +262,10 @@ func (c *Config) ApplyOptions(opts ...Option) error {
 //	)
 func WithConnectionOption(opt hsms.ConnOption) Option {
 	return func(c *Config) error {
+		if opt == nil {
+			return errors.New("WithConnectionOption: connection option must not be nil")
+		}
+
 		return opt(&c.ConnectionConfig)
 	}
 }

--- a/hsmsss/config_test.go
+++ b/hsmsss/config_test.go
@@ -1,12 +1,14 @@
 package hsmsss_test
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/arloliu/go-secs/v2/hsms"
 	"github.com/arloliu/go-secs/v2/hsmsss"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewConfig_Defaults verifies that NewConfig produces a Config whose
@@ -44,6 +46,47 @@ func TestNewConfig_Defaults(t *testing.T) {
 	// Session ID must be 0xFFFF (E37.1 single-session default).
 	if cfg.SessionID() != 0xFFFF {
 		t.Errorf("SessionID() = 0x%04X, want 0xFFFF", cfg.SessionID())
+	}
+}
+
+func TestNewConfig_NilOptionsReturnErrors(t *testing.T) {
+	_, err := hsmsss.NewConfig("127.0.0.1", 5000, nil)
+	require.ErrorContains(t, err, "option must not be nil")
+
+	_, err = hsmsss.NewConfig("127.0.0.1", 5000, hsmsss.WithConnectionOption(nil))
+	require.ErrorContains(t, err, "connection option must not be nil")
+}
+
+func TestApplyOptions_NilOptionsAreTransactional(t *testing.T) {
+	tests := []struct {
+		name    string
+		nilLike hsmsss.Option
+		wantErr string
+	}{
+		{name: "nil option", nilLike: nil, wantErr: "option must not be nil"},
+		{
+			name:    "nil connection option",
+			nilLike: hsmsss.WithConnectionOption(nil),
+			wantErr: "connection option must not be nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := hsmsss.NewConfig("127.0.0.1", 5000)
+			require.NoError(t, err)
+			origKeepAlive := cfg.TCPKeepAlive()
+			siblingErr := errors.New("sibling option failed")
+
+			err = cfg.ApplyOptions(
+				hsmsss.WithTCPKeepAlive(10*time.Second),
+				tt.nilLike,
+				func(*hsmsss.Config) error { return siblingErr },
+			)
+			require.ErrorContains(t, err, tt.wantErr)
+			require.ErrorIs(t, err, siblingErr)
+			require.Equal(t, origKeepAlive, cfg.TCPKeepAlive(), "valid option must not commit when a sibling fails")
+		})
 	}
 }
 

--- a/hsmsss/metrics.go
+++ b/hsmsss/metrics.go
@@ -12,7 +12,7 @@ import "sync/atomic"
 type ConnectionMetrics struct {
 	linktestSend       atomic.Uint64 // Linktest.req ATTEMPTED by our own auto-linktest (counted before the write)
 	linktestRecv       atomic.Uint64 // Linktest.rsp received (successful round-trip)
-	linktestErr        atomic.Uint64 // our own linktest round-trip failed (T6 timeout or write error)
+	linktestErr        atomic.Uint64 // our own linktest round-trip failed (T6 expiry, write failure, or peer rejection)
 	selectEstablished  atomic.Uint64 // Select responder committed NotSelected -> Selected (E37 §7.4)
 	separateRecv       atomic.Uint64 // peer Separate.req received in any connected substate (peer-initiated teardown, E37.1 §7.6)
 	rejectSent         atomic.Uint64 // Reject.req WE emit (peer sent us a malformed/unexpected frame)

--- a/hsmsss/metrics.go
+++ b/hsmsss/metrics.go
@@ -41,7 +41,8 @@ func (m *ConnectionMetrics) LinktestRecvCount() uint64 {
 
 // LinktestErrCount returns the cumulative number of failed initiator linktest attempts.
 //
-// A failure is defined as a T6 timeout or a write error on a live link.
+// It counts any failed initiator round trip on a live link,
+// including T6 expiry, write failure, and peer rejection.
 // A linktest aborted by connection teardown (Close, Deselect, drop) is excluded —
 // that outcome is already signaled through the disconnect path, not this counter.
 // It only ever grows and is purely observational — it never influences the linktest-fail-threshold disconnect decision.
@@ -54,11 +55,10 @@ func (m *ConnectionMetrics) SelectEstablishedCount() uint64 {
 	return m.selectEstablished.Load()
 }
 
-// SeparateRecvCount returns the total number of inbound Separate.req messages received (each one tears down the connection —
-// a peer-initiated disconnect, E37.1 §7.6).
+// SeparateRecvCount returns the total number of inbound Separate.req messages received.
 //
-// Every Selected or NotSelected substate counts;
-// E37.1 §7.6 requires an immediate close on receiving a Separate.req regardless of the selection state.
+// It counts each inbound request whether or not it belongs to the still-current generation.
+// A request from the current generation tears down the connection as a peer-initiated disconnect (E37.1 §7.6).
 func (m *ConnectionMetrics) SeparateRecvCount() uint64 {
 	return m.separateRecv.Load()
 }

--- a/hsmsss/new.go
+++ b/hsmsss/new.go
@@ -35,13 +35,16 @@ type Connection interface {
 // This is the consumer entry point for the HSMS-SS transport: the engine lives once in the hsms package,
 // and the application holds only the Connection/hsms.Connection interface.
 //
-// cfg MUST originate from [NewConfig], which seeds the default TCP dialer.
-// Passing a hand-built [Config] literal leaves the dialer nil and will cause New to return a clear error for the active role.
+// cfg MUST originate from [NewConfig], which seeds the default TCP dialer and listener.
+// Passing a hand-built [Config] literal leaves the role-specific function nil and will cause New to return a clear error.
 //
 // Always use [NewConfig].
 func New(cfg Config) (Connection, error) {
 	if cfg.active && cfg.dial == nil {
 		return nil, errors.New("hsmsss: active Config has a nil dialer; always construct Config via NewConfig")
+	}
+	if !cfg.active && cfg.listen == nil {
+		return nil, errors.New("hsmsss: passive Config has a nil listener; always construct Config via NewConfig")
 	}
 
 	t := newTransport(cfg)

--- a/hsmsss/new_test.go
+++ b/hsmsss/new_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 // TestNew_NilDialerReturnsError verifies that a hand-built active Config with a nil dialer causes
-// New to return a clear error instead of panicking. Passive role is unaffected.
+// New to return a clear error instead of panicking.
 func TestNew_NilDialerReturnsError(t *testing.T) {
 	t.Parallel()
 
@@ -34,6 +34,15 @@ func TestNew_NilDialerReturnsError(t *testing.T) {
 	require.Error(t, err, "active Config with nil dialer must return an error")
 	require.Contains(t, err.Error(), "nil dialer")
 	require.Contains(t, err.Error(), "NewConfig")
+}
+
+func TestNew_NilListenerReturnsError(t *testing.T) {
+	t.Parallel()
+
+	var cfg Config
+	_, err := New(cfg)
+	require.ErrorContains(t, err, "nil listener")
+	require.ErrorContains(t, err, "NewConfig")
 }
 
 // TestNew_ReturnsUsableConnection verifies New builds a non-nil hsms.Connection (nil error) for

--- a/hsmsss/transport_recv.go
+++ b/hsmsss/transport_recv.go
@@ -127,13 +127,16 @@ func (t *transport) dispatchFrame(genCtx context.Context, g *genWG, frame []byte
 		return true
 	}
 
-	trace, log := t.cfg.TraceTraffic(), t.cfg.Logger()
-	if rt, ok := t.rt.(traceConfigRuntime); ok {
-		trace, log = rt.TraceConfig()
-	}
-	if msgType != hsms.DataMsgType && trace {
-		log.Debug("hsmsss: trace: received control frame",
-			"stype", sType, "raw", hexDumpFrame(frame))
+	if msgType != hsms.DataMsgType {
+		trace, log := t.cfg.TraceTraffic(), t.cfg.Logger()
+		if rt, ok := t.rt.(traceConfigRuntime); ok {
+			trace, log = rt.TraceConfig()
+		}
+
+		if trace {
+			log.Debug("hsmsss: trace: received control frame",
+				"stype", sType, "raw", hexDumpFrame(frame))
+		}
 	}
 
 	switch msgType { //nolint:exhaustive // UndefinedMsgType is filtered by IsValidSType above; default is unreachable.

--- a/hsmsss/transport_recv.go
+++ b/hsmsss/transport_recv.go
@@ -10,8 +10,13 @@ import (
 	"time"
 
 	"github.com/arloliu/go-secs/v2/hsms"
+	"github.com/arloliu/go-secs/v2/logger"
 	"github.com/arloliu/go-secs/v2/secs2"
 )
+
+type traceConfigRuntime interface {
+	TraceConfig() (bool, logger.Logger)
+}
 
 // makeFrame is the default frame allocator: a fresh GC-owned buffer of n bytes (NOT pooled,
 // §5.F option (b)). It is the production value of transport.allocFrame; tests override the
@@ -122,8 +127,12 @@ func (t *transport) dispatchFrame(genCtx context.Context, g *genWG, frame []byte
 		return true
 	}
 
-	if msgType != hsms.DataMsgType && t.cfg.TraceTraffic() {
-		t.cfg.Logger().Debug("hsmsss: trace: received control frame",
+	trace, log := t.cfg.TraceTraffic(), t.cfg.Logger()
+	if rt, ok := t.rt.(traceConfigRuntime); ok {
+		trace, log = rt.TraceConfig()
+	}
+	if msgType != hsms.DataMsgType && trace {
+		log.Debug("hsmsss: trace: received control frame",
 			"stype", sType, "raw", hexDumpFrame(frame))
 	}
 

--- a/hsmsss/transport_recv_test.go
+++ b/hsmsss/transport_recv_test.go
@@ -21,9 +21,8 @@ import (
 	"time"
 
 	"github.com/arloliu/go-secs/v2/hsms"
-	"github.com/arloliu/go-secs/v2/logger/loggertest"
+	"github.com/arloliu/go-secs/v2/logger"
 	"github.com/arloliu/go-secs/v2/secs2"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,6 +44,46 @@ func (g *testSysGen) next() [4]byte {
 	binary.BigEndian.PutUint32(b[:], g.n.Add(1))
 
 	return b
+}
+
+type traceRecord struct {
+	msg     string
+	keyvals []any
+}
+
+type traceCaptureLogger struct {
+	mu      sync.Mutex
+	records []traceRecord
+}
+
+func (l *traceCaptureLogger) Debug(msg string, keyvals ...any) {
+	l.mu.Lock()
+	l.records = append(l.records, traceRecord{msg: msg, keyvals: append([]any(nil), keyvals...)})
+	l.mu.Unlock()
+}
+
+func (*traceCaptureLogger) Info(string, ...any)  {}
+func (*traceCaptureLogger) Warn(string, ...any)  {}
+func (*traceCaptureLogger) Error(string, ...any) {}
+func (*traceCaptureLogger) Fatal(string, ...any) {}
+func (l *traceCaptureLogger) With(...any) logger.Logger {
+	return l
+}
+func (*traceCaptureLogger) Level() logger.LogLevel   { return logger.DebugLevel }
+func (*traceCaptureLogger) SetLevel(logger.LogLevel) {}
+
+func (l *traceCaptureLogger) count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return len(l.records)
+}
+
+func (l *traceCaptureLogger) last() traceRecord {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.records[len(l.records)-1]
 }
 
 type recRT struct {
@@ -69,6 +108,8 @@ type recRT struct {
 	// (the active Select procedure parks there — unchanged from the framed-reader tests).
 	writeMsgFn      func(ctx context.Context, msg hsms.Message) (hsms.Message, error)
 	selectLostCount int // number of SelectLost() calls (Deselect responder transition)
+	traceEnabled    bool
+	traceLogger     logger.Logger
 
 	t7ExpiredCount int           // number of T7Expired() calls (NOT-SELECTED dwell expiry)
 	t7ExpiredCh    chan struct{} // closed on the FIRST T7Expired call
@@ -87,6 +128,14 @@ type recRT struct {
 	deliveredCh       chan struct{} // when non-nil, closed once on the FIRST DeliverOwnedFrame (delivery observed)
 	deliveredJustOnce sync.Once
 }
+
+// runtimeWithoutTraceConfig preserves only the TransportRuntime method set of its wrapped runtime.
+// Its dynamic type deliberately does not provide the optional traceConfigRuntime capability.
+type runtimeWithoutTraceConfig struct {
+	hsms.TransportRuntime
+}
+
+var _ hsms.TransportRuntime = runtimeWithoutTraceConfig{}
 
 func newRecRT() *recRT {
 	rt := &recRT{
@@ -199,6 +248,20 @@ func (m *recRT) LinktestFailThreshold() int {
 	defer m.mu.Unlock()
 
 	return m.linktestFailThreshold
+}
+
+func (m *recRT) TraceConfig() (bool, logger.Logger) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.traceEnabled, m.traceLogger
+}
+
+func (m *recRT) setTraceConfig(enabled bool, log logger.Logger) {
+	m.mu.Lock()
+	m.traceEnabled = enabled
+	m.traceLogger = log
+	m.mu.Unlock()
 }
 
 // setLinktest configures the auto-linktest interval/threshold before startLinktest is called.
@@ -370,7 +433,7 @@ func (m *recRT) tcpDownDidFire() bool {
 // plus the peer end of the connection (from which the test writes frames byte-streams and
 // reads any Reject the reader emits). setups run after newTransport but BEFORE Start, so a
 // test can install the allocFrame seam before the recv loop spawns (J2).
-func startReader(t *testing.T, rt *recRT, opts []Option, setups ...func(*transport)) *net.TCPConn {
+func startReader(t *testing.T, rt hsms.TransportRuntime, opts []Option, setups ...func(*transport)) *net.TCPConn {
 	t.Helper()
 
 	ln, port := listenLoopback(t)
@@ -599,56 +662,85 @@ func TestReader_ControlFrameLenNot10Rejected(t *testing.T) {
 	require.False(t, rt.tcpDownDidFire(), "a Reject must keep the link (no TCPDown)")
 }
 
-// TestDispatchFrame_TraceTraffic_LogsControlFrame proves that with WithTraceTraffic enabled, an
-// inbound control frame (here Linktest.req) logs a Debug line via dispatchFrame's control-only
-// trace hook (data frames are traced separately in hsms.DeliverOwnedFrame, so this hook excludes
-// them to avoid a double log) — and that the logged keysAndValues carry the real stype and hex-dump
-// payload (matching the pattern in hsms/connection_send_test.go's
-// TestWriteFrame_TraceTraffic_LogsSentFrame), not just that SOME Debug call happened.
-//
-// The Debug call happens on the recv goroutine while this test goroutine observes it, so
-// completion is signalled via a channel closed from testify's Run callback (mirroring recRT's
-// tcpDownCh/t7ExpiredCh pattern) rather than polling mockLog.Calls directly — reading that field
-// without the mock's internal lock would race with MethodCalled's concurrent append (-race). The
-// callback itself runs synchronously on the recv goroutine inside MethodCalled, so capturing its
-// Arguments into a test-goroutine-owned variable here is safe (no concurrent access to it until
-// after loggedCh is observed to have fired).
-func TestDispatchFrame_TraceTraffic_LogsControlFrame(t *testing.T) {
-	t.Parallel()
-
-	loggedCh := make(chan struct{})
-	var loggedOnce sync.Once
-	var keyvals []any
-
-	mockLog := loggertest.NewMockLogger()
-	mockLog.On("Debug", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		kv, ok := args[1].([]any)
-		require.True(t, ok, "Debug's variadic keysAndValues must be forwarded as a []any slice")
-		keyvals = kv
-		loggedOnce.Do(func() { close(loggedCh) })
-	}).Return()
-
+func TestDispatchFrame_TraceTraffic_UsesLiveConfig(t *testing.T) {
 	rt := newRecRT()
+	frozenLog := &traceCaptureLogger{}
 	peer := startReader(t, rt, []Option{
-		WithConnectionOption(hsms.WithTraceTraffic(true)),
-		WithConnectionOption(hsms.WithLogger(mockLog)),
+		WithConnectionOption(hsms.WithTraceTraffic(false)),
+		WithConnectionOption(hsms.WithLogger(frozenLog)),
 	})
+
+	liveLog := &traceCaptureLogger{}
+	rt.setTraceConfig(true, liveLog)
 
 	header := header10(0, byte(hsms.LinktestReqType))
 	wire := frameBytes(10, header, nil)
 	_, err := peer.Write(wire)
 	require.NoError(t, err)
+	require.Eventually(t, func() bool { return rt.sentCount() == 1 },
+		5*time.Second, 10*time.Millisecond, "first Linktest.req must be handled")
 
-	select {
-	case <-loggedCh:
-	case <-time.After(15 * time.Second):
-		t.Fatal("a traced inbound control frame must log at Debug level")
-	}
-
-	require.Contains(t, keyvals, byte(hsms.LinktestReqType),
+	require.Equal(t, 1, liveLog.count())
+	require.Zero(t, frozenLog.count())
+	record := liveLog.last()
+	require.Equal(t, "hsmsss: trace: received control frame", record.msg)
+	require.Contains(t, record.keyvals, byte(hsms.LinktestReqType),
 		"the logged keysAndValues must carry the frame's real stype")
-	require.Contains(t, keyvals, hexDumpFrame(header),
+	require.Contains(t, record.keyvals, hexDumpFrame(header),
 		"the logged keysAndValues must carry the exact frame hex dump")
+
+	rt.setTraceConfig(false, liveLog)
+	header[9]++
+	_, err = peer.Write(frameBytes(10, header, nil))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return rt.sentCount() == 2 },
+		5*time.Second, 10*time.Millisecond, "second Linktest.req must be handled")
+	require.Equal(t, 1, liveLog.count(), "disabling live tracing must suppress later control-frame logs")
+}
+
+func TestDispatchFrame_TraceTraffic_LiveDisableOverridesConstruction(t *testing.T) {
+	rt := newRecRT()
+	frozenLog := &traceCaptureLogger{}
+	peer := startReader(t, rt, []Option{
+		WithConnectionOption(hsms.WithTraceTraffic(true)),
+		WithConnectionOption(hsms.WithLogger(frozenLog)),
+	})
+
+	liveLog := &traceCaptureLogger{}
+	rt.setTraceConfig(false, liveLog)
+
+	header := header10(0, byte(hsms.LinktestReqType))
+	_, err := peer.Write(frameBytes(10, header, nil))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return rt.sentCount() == 1 },
+		5*time.Second, 10*time.Millisecond, "Linktest.req must be handled before checking trace suppression")
+	require.Zero(t, liveLog.count(), "live disablement must override construction-time enablement")
+	require.Zero(t, frozenLog.count(), "the frozen logger must not receive a live-disabled trace")
+}
+
+func TestDispatchFrame_TraceTraffic_WithoutCapabilityUsesConstructionConfig(t *testing.T) {
+	baseRT := newRecRT()
+	rt := runtimeWithoutTraceConfig{TransportRuntime: baseRT}
+	_, hasTraceConfig := any(rt).(traceConfigRuntime)
+	require.False(t, hasTraceConfig, "fallback runtime must not implement the optional trace capability")
+
+	frozenLog := &traceCaptureLogger{}
+	peer := startReader(t, rt, []Option{
+		WithConnectionOption(hsms.WithTraceTraffic(true)),
+		WithConnectionOption(hsms.WithLogger(frozenLog)),
+	})
+
+	header := header10(0, byte(hsms.LinktestReqType))
+	_, err := peer.Write(frameBytes(10, header, nil))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return baseRT.sentCount() == 1 },
+		5*time.Second, 10*time.Millisecond, "Linktest.req must be handled before checking fallback tracing")
+
+	require.Equal(t, 1, frozenLog.count())
+	record := frozenLog.last()
+	require.Equal(t, "hsmsss: trace: received control frame", record.msg)
+	require.Contains(t, record.keyvals, byte(hsms.LinktestReqType))
+	require.Contains(t, record.keyvals, hexDumpFrame(header))
 }
 
 // TestReader_UnsupportedSTypeRejectsKeepsLink (J3, §7.10.3) — an undefined SType is answered

--- a/integration/fsm_matrix_test.go
+++ b/integration/fsm_matrix_test.go
@@ -307,14 +307,18 @@ func TestFSM_HSMSSSMatrix(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
+		// Mark BEFORE Open: the notifier records on its own goroutine, so both transitions can land
+		// while this goroutine is still descheduled.
+		marked := rec.mark()
+
 		require.NoError(t, conn.Open(ctx, hsms.OpenBackground))
 
 		// The line comes up to NotSelected ...
-		require.True(t, rec.awaitState(hsms.NotSelectedState, 15*time.Second),
-			"the line must come up to NotSelected with the Select.rsp withheld")
+		up, ok := rec.awaitStateFrom(marked, hsms.NotSelectedState, 15*time.Second)
+		require.True(t, ok, "the line must come up to NotSelected with the Select.rsp withheld")
 		// ... then the T7 dwell expires and disconnects it.
-		require.True(t, rec.awaitState(hsms.NotConnectedState, 15*time.Second),
-			"the T7 (NOT-SELECTED) dwell must expire and disconnect")
+		_, ok = rec.awaitStateFrom(up+1, hsms.NotConnectedState, 15*time.Second)
+		require.True(t, ok, "the T7 (NOT-SELECTED) dwell must expire and disconnect")
 
 		p := rec.pairs()
 		require.True(t, hasStateEdge(p, hsms.NotConnectedState, hsms.NotSelectedState),
@@ -444,15 +448,20 @@ func TestFSM_SECS1Matrix(t *testing.T) {
 		return hasStateEdge(rec.pairs(), hsms.NotConnectedState, hsms.SelectedState)
 	}, 15*time.Second, 5*time.Millisecond, "a live SECS-I line must auto-commit NotConnected -> Selected")
 
+	// Mark BEFORE the drop: a SECS-I teardown lands within one poll tick (10ms), so a mark taken
+	// after dropLine can already sit past the teardown edge and the wait would then miss it.
+	marked := rec.mark()
+
 	// Drop the live line involuntarily: the connection tears down (Selected -> NotConnected) and the
 	// reconnect loop redials a fresh generation that auto-commits back to Selected.
 	dropped := latestScriptable(t, df)
 	dropped.dropLine()
 
-	require.True(t, rec.awaitState(hsms.NotConnectedState, 3*time.Second),
-		"an involuntary line drop must tear the SECS-I line down to NotConnected")
-	require.True(t, rec.awaitState(hsms.SelectedState, 3*time.Second),
-		"the reconnect must auto-commit the fresh SECS-I line back to Selected")
+	torn, ok := rec.awaitStateFrom(marked, hsms.NotConnectedState, 3*time.Second)
+	require.True(t, ok, "an involuntary line drop must tear the SECS-I line down to NotConnected")
+	// Resume past the teardown match so the pre-drop Selected cannot satisfy this wait.
+	_, ok = rec.awaitStateFrom(torn+1, hsms.SelectedState, 3*time.Second)
+	require.True(t, ok, "the reconnect must auto-commit the fresh SECS-I line back to Selected")
 
 	// Close settles the terminal Selected -> NotConnected edge and joins the notifier, so the whole
 	// lifecycle sequence is final once Close returns.

--- a/integration/parity_test.go
+++ b/integration/parity_test.go
@@ -244,19 +244,22 @@ func TestParity_InvoluntaryDropReconnects(t *testing.T) {
 
 			require.Equal(t, hsms.SelectedState, conn.State())
 
+			// Mark BEFORE the drop: teardown lands within one secs1 poll tick (10ms), so a mark taken
+			// after dropLine can already sit past the teardown edge and the wait would then miss it.
+			marked := rec.mark()
+
 			// Abruptly drop the live peer: the connection's recv sees EOF and the FSM tears down.
 			dropped := latestScriptable(t, df)
 			dropped.dropLine()
 
-			// First observe the fresh teardown, then the fresh re-Select. Waiting on NotConnected first
-			// also absorbs the initial Selected notification (delivered asynchronously by the notifier, it
-			// may still be in flight when Open returns), so the subsequent Selected wait cannot mistake the
-			// stale initial Selected for the reconnect's — it detects the genuine re-Selected edge, which
-			// only a fresh dial (a new generation) can produce.
-			require.True(t, rec.awaitState(hsms.NotConnectedState, 3*time.Second),
-				"connection did not tear down after the involuntary drop")
-			require.True(t, rec.awaitState(hsms.SelectedState, 3*time.Second),
-				"connection did not re-Select after the involuntary drop")
+			// First observe the fresh teardown, then the fresh re-Select. The re-Select wait resumes at
+			// the edge AFTER the teardown match, so it cannot mistake the initial Selected (recorded
+			// before the drop) for the reconnect's — it detects the genuine re-Selected edge, which only
+			// a fresh dial (a new generation) can produce.
+			torn, ok := rec.awaitStateFrom(marked, hsms.NotConnectedState, 3*time.Second)
+			require.True(t, ok, "connection did not tear down after the involuntary drop")
+			_, ok = rec.awaitStateFrom(torn+1, hsms.SelectedState, 3*time.Second)
+			require.True(t, ok, "connection did not re-Select after the involuntary drop")
 
 			// The reconnect must have dialed a fresh-generation peer, distinct from the dropped one.
 			reconnected := latestScriptable(t, df)

--- a/integration/state_test.go
+++ b/integration/state_test.go
@@ -54,20 +54,40 @@ func (r *stateRecorder) pairs() []stateEdge {
 	return append([]stateEdge(nil), r.edges...)
 }
 
-// awaitState blocks until a transition whose next state equals target is recorded AFTER this call
-// began, or timeout elapses. It reports whether such a fresh transition occurred.
+// mark returns the current edge count, to be passed to a later awaitStateFrom as its scan origin.
 //
-// "Fresh" is the load-bearing detail: it snapshots the current edge count on entry and only scans
-// transitions recorded from that point forward, so a target already reached before the call (for
-// example the initial Selected) does NOT satisfy the wait — only a genuinely new edge to target
-// (for example the re-Selected that follows an involuntary drop) does. It parks on a condition
-// variable, woken by record or by a one-shot timer at the deadline, so it never busy-loops.
-func (r *stateRecorder) awaitState(target hsms.ConnState, timeout time.Duration) bool {
+// Take the mark BEFORE the action that triggers the transition, never after.
+// The notifier records on its own goroutine,
+// so a teardown can be recorded while the test goroutine is still descheduled between the trigger and the wait.
+// secs1 tears down within one linePollInterval (10ms), which is well inside a scheduling hiccup under -race.
+// A mark taken after the trigger can therefore sit past the very edge the wait is looking for,
+// and the wait then blocks for its full timeout on a transition that already happened.
+func (r *stateRecorder) mark() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Only edges recorded from here forward count as a fresh transition to target.
-	scanned := len(r.edges)
+	return len(r.edges)
+}
+
+// awaitStateFrom blocks until a transition whose next state equals target is recorded at or after edge index from,
+// or timeout elapses.
+// It returns the index the match was found at and whether a match occurred;
+// on timeout it returns from unchanged and false.
+//
+// Chain sequential waits with the returned index — pass matched+1 to the next call —
+// so each wait scans strictly past its predecessor's match.
+// Restarting a follow-up wait from the ORIGINAL mark would let an edge recorded before the trigger satisfy it:
+// after an involuntary drop,
+// a Selected wait rooted at the pre-drop mark matches the INITIAL Selected and returns immediately,
+// passing without any reconnect having occurred.
+func (r *stateRecorder) awaitStateFrom(from int, target hsms.ConnState, timeout time.Duration) (int, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	scanned := from
+	if scanned < 0 {
+		scanned = 0
+	}
 
 	deadline := time.Now().Add(timeout)
 
@@ -83,12 +103,12 @@ func (r *stateRecorder) awaitState(target hsms.ConnState, timeout time.Duration)
 	for {
 		for ; scanned < len(r.edges); scanned++ {
 			if r.edges[scanned].next == target {
-				return true
+				return scanned, true
 			}
 		}
 
 		if !time.Now().Before(deadline) {
-			return false
+			return from, false
 		}
 
 		r.cond.Wait()

--- a/secs1/config.go
+++ b/secs1/config.go
@@ -113,6 +113,11 @@ func (c *Config) apply(opts ...Option) error {
 	var errs []error
 
 	for _, opt := range opts {
+		if opt == nil {
+			errs = append(errs, errors.New("secs1: option must not be nil"))
+			continue
+		}
+
 		if err := opt(&scratch); err != nil {
 			errs = append(errs, err)
 		}
@@ -373,6 +378,10 @@ func WithTCPKeepAlive(d time.Duration) Option {
 //	)
 func WithConnectionOption(opt hsms.ConnOption) Option {
 	return func(c *Config) error {
+		if opt == nil {
+			return errors.New("WithConnectionOption: connection option must not be nil")
+		}
+
 		return opt(&c.ConnectionConfig)
 	}
 }

--- a/secs1/config_test.go
+++ b/secs1/config_test.go
@@ -6,6 +6,7 @@ package secs1
 // value-receiver accessors. No network and no time.Sleep — the transport seam is never opened here.
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -29,6 +30,47 @@ func TestNewConfig_Defaults(t *testing.T) {
 	require.Equal(t, 3, cfg.RetryLimit(), "default RetryLimit")
 	require.False(t, cfg.IsEquip(), "default role is host (slave)")
 	require.Equal(t, uint16(0), cfg.DeviceID(), "default deviceID")
+}
+
+func TestNewConfig_NilOptionsReturnErrors(t *testing.T) {
+	_, err := NewConfig("127.0.0.1", 5000, nil)
+	require.ErrorContains(t, err, "option must not be nil")
+
+	_, err = NewConfig("127.0.0.1", 5000, WithConnectionOption(nil))
+	require.ErrorContains(t, err, "connection option must not be nil")
+}
+
+func TestApplyOptions_NilOptionsAreTransactional(t *testing.T) {
+	tests := []struct {
+		name    string
+		nilLike Option
+		wantErr string
+	}{
+		{name: "nil option", nilLike: nil, wantErr: "option must not be nil"},
+		{
+			name:    "nil connection option",
+			nilLike: WithConnectionOption(nil),
+			wantErr: "connection option must not be nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := NewConfig("127.0.0.1", 5000)
+			require.NoError(t, err)
+			origKeepAlive := cfg.TCPKeepAlive()
+			siblingErr := errors.New("sibling option failed")
+
+			err = cfg.ApplyOptions(
+				WithTCPKeepAlive(10*time.Second),
+				tt.nilLike,
+				func(*Config) error { return siblingErr },
+			)
+			require.ErrorContains(t, err, tt.wantErr)
+			require.ErrorIs(t, err, siblingErr)
+			require.Equal(t, origKeepAlive, cfg.TCPKeepAlive(), "valid option must not commit when a sibling fails")
+		})
+	}
 }
 
 // TestNewConfig_WriteTimeoutInvariant asserts the D5b-11 invariant: the embedded core writeTimeout

--- a/secs1/doc.go
+++ b/secs1/doc.go
@@ -20,8 +20,14 @@
 // and the equipment/host role and device ID.
 // The core reply timeout is the embedded T3.
 //
-// [New] forces the core write timeout to 0 (disabled): a SECS-I line transaction self-bounds via T2×(RTY+1),
-// so a core write deadline is redundant and would spuriously preempt a legitimately retrying send.
+// [New] forces the core write timeout to 0 (disabled).
+// T2 bounds waits for protocol responses, and RTY bounds the number of failed protocol retries.
+// Neither bounds socket writes; the line engine performs them without a write deadline,
+// and connection teardown closes the socket to interrupt blocked I/O.
+// Each successful slave contention yield restarts the postponed send as a fresh request under E4,
+// so repeated successful master traffic can postpone the local send until the connection generation ends.
+// Close or connection teardown releases a blocked write through the generation's teardown signal.
+// A core write deadline would interfere with the line engine's socket-deadline ownership.
 // The override is enforced both at construction — [NewConfig] applies it as the LAST option, after all caller-supplied options —
 // and at runtime: Connection.UpdateConfigOptions re-appends hsms.WithWriteTimeout(0) after the caller's options,
 // so a WithWriteTimeout supplied at runtime is intercepted and neutralized rather than taking effect.
@@ -31,7 +37,12 @@
 // SECS-I is a half-duplex block protocol: only one party drives the line at a time.
 // A single line-engine goroutine owns the connection for each generation — it is the only code that reads or writes socket bytes —
 // alternating between draining a pending outbound send and polling for an inbound block.
-// Each block transfer is an ENQ/EOT/ACK/NAK handshake bounded by T1/T2; a block that is not ACK'd is retransmitted up to RTY times,
+// T2 bounds waits for EOT, the length byte, and ACK;
+// T1 bounds inter-character waits while receiving the block body.
+// Socket writes are not timer-bounded.
+// After an invalid length or checksum, the receiver drains until T1 silence;
+// each arriving chunk restarts T1, so a peer can keep the drain active until connection teardown.
+// A block is retransmitted up to RTY times after a retryable protocol-response failure,
 // and simultaneous send attempts are arbitrated by contention (the master — the equipment, per IsEquip — wins;
 // the slave yields, delivers the master's block, then re-sends its own as a fresh transaction).
 // A block send that exhausts RTY returns an error from the transport, which the core treats as a line failure:

--- a/secs1/line.go
+++ b/secs1/line.go
@@ -3,6 +3,7 @@ package secs1
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -100,6 +101,12 @@ func (l *lineIO) writeByte(b byte) error {
 	return err
 }
 
+func (l *lineIO) sendNAK() {
+	if err := l.writeByte(nak); err == nil {
+		l.metrics.incBlockNAKSentCount()
+	}
+}
+
 // writeAll writes all of data to the conn, looping over short writes.
 func (l *lineIO) writeAll(data []byte) error {
 	for written := 0; written < len(data); {
@@ -133,10 +140,12 @@ func (l *lineIO) drainUntilSilence() {
 // response to the peer's ENQ. The steps, per SEMI E4 §7.8.5:
 //
 //  1. Read the length byte with T2. On timeout: NAK, return ErrT2Timeout.
+//     On another I/O failure: return it without NAK.
 //  2. Validate the length range [minBlockLength, maxBlockLength]. On failure: drain, NAK,
 //     return ErrInvalidLength.
 //  3. Read header+body+checksum into a FRESH owned buffer with a per-read T1 deadline. On timeout:
 //     NAK, return ErrT1Timeout.
+//     On another I/O failure: return it without NAK.
 //  4. parseBlock (length + checksum). On failure: drain, NAK, return the parse error.
 //  5. On success: ACK and return the block.
 //
@@ -153,10 +162,13 @@ func (l *lineIO) receiveBlock(ctx context.Context) (block, error) {
 	// character ... an NAK is sent").
 	lengthByte, err := l.readByte(l.timers().T2)
 	if err != nil {
-		_ = l.writeByte(nak)
-		l.metrics.incBlockNAKSentCount()
+		if isTimeout(err) {
+			l.sendNAK()
 
-		return block{}, fmt.Errorf("%w: waiting for length byte: %w", ErrT2Timeout, err)
+			return block{}, fmt.Errorf("%w: waiting for length byte: %w", ErrT2Timeout, err)
+		}
+
+		return block{}, fmt.Errorf("secs1: waiting for length byte: %w", err)
 	}
 
 	// Step 2: validate the length range (§7.6: 10 <= N <= 254). On an invalid length the receiver
@@ -164,8 +176,7 @@ func (l *lineIO) receiveBlock(ctx context.Context) (block, error) {
 	n := int(lengthByte)
 	if n < minBlockLength || n > maxBlockLength {
 		l.drainUntilSilence()
-		_ = l.writeByte(nak)
-		l.metrics.incBlockNAKSentCount()
+		l.sendNAK()
 
 		return block{}, fmt.Errorf("%w: length byte %d out of [%d, %d]", ErrInvalidLength, n, minBlockLength, maxBlockLength)
 	}
@@ -174,10 +185,13 @@ func (l *lineIO) receiveBlock(ctx context.Context) (block, error) {
 	// between characters being received, then an NAK is sent".
 	buf := make([]byte, n+checksumSize)
 	if err := l.readFull(buf); err != nil {
-		_ = l.writeByte(nak)
-		l.metrics.incBlockNAKSentCount()
+		if isTimeout(err) {
+			l.sendNAK()
 
-		return block{}, fmt.Errorf("%w: reading block data: %w", ErrT1Timeout, err)
+			return block{}, fmt.Errorf("%w: reading block data: %w", ErrT1Timeout, err)
+		}
+
+		return block{}, fmt.Errorf("secs1: reading block data: %w", err)
 	}
 
 	// Step 4: parse + checksum. §7.8.5: on a checksum mismatch the receiver keeps listening (drain)
@@ -185,8 +199,7 @@ func (l *lineIO) receiveBlock(ctx context.Context) (block, error) {
 	blk, err := parseBlock(lengthByte, buf)
 	if err != nil {
 		l.drainUntilSilence()
-		_ = l.writeByte(nak)
-		l.metrics.incBlockNAKSentCount()
+		l.sendNAK()
 
 		return block{}, err
 	}
@@ -214,14 +227,14 @@ func (l *lineIO) receiveBlock(ctx context.Context) (block, error) {
 //   - sendContention => this end is the slave and the peer contended (ENQ). sendBlockOnce only
 //     DETECTS this; T2 owns the yield ACTION (send EOT, receiveBlock, deliver the peer's block,
 //     then re-attempt this send with the retry counter reset per §7.8.2.1).
-//   - sendAbort      => non-retryable (write error or context cancellation); return the error.
+//   - sendAbort      => non-retryable (I/O error or context cancellation); return the error.
 type sendResult int
 
 const (
 	sendOK         sendResult = iota // block sent and ACK'd
 	sendRetry                        // retryable failure (T2 timeout, NAK, non-ACK)
 	sendContention                   // slave detected contention (T2 performs the yield)
-	sendAbort                        // non-retryable failure (write error, context cancelled)
+	sendAbort                        // non-retryable failure (I/O error, context cancelled)
 )
 
 // sendBlockOnce performs ONE line-control handshake and block transmission attempt (SEMI E4 §7.8.2):
@@ -258,7 +271,11 @@ func (l *lineIO) sendBlockOnce(ctx context.Context, blk block) (sendResult, erro
 
 		b, err := l.readByte(remaining)
 		if err != nil {
-			return sendRetry, fmt.Errorf("%w: waiting for EOT after ENQ: %w", ErrT2Timeout, err)
+			if isTimeout(err) {
+				return sendRetry, fmt.Errorf("%w: waiting for EOT after ENQ: %w", ErrT2Timeout, err)
+			}
+
+			return sendAbort, fmt.Errorf("secs1: waiting for EOT after ENQ: %w", err)
 		}
 
 		switch {
@@ -280,11 +297,12 @@ func (l *lineIO) sendBlockOnce(ctx context.Context, blk block) (sendResult, erro
 // sendBlockData transmits the packed block and waits for ACK within T2 (SEMI E4 §7.8.3):
 //
 //  1. Write the wire frame [lengthByte][header][body][checksum].
-//  2. Wait up to T2 for one byte: ACK => sendOK; any non-ACK byte => sendRetry; a read error or T2
-//     timeout => sendRetry (ErrT2Timeout).
+//  2. Wait up to T2 for one byte: ACK => sendOK; any non-ACK byte => sendRetry; a T2 timeout =>
+//     sendRetry (ErrT2Timeout); another read error => sendAbort.
 //
-// A write error is non-retryable (sendAbort). Per §7.8.3, characters received before the last
-// checksum byte are ignored — the caller drained them within the T2 wait for EOT.
+// An I/O error is non-retryable (sendAbort).
+// Per §7.8.3, characters received before the last checksum byte are ignored;
+// the caller drained them within the T2 wait for EOT.
 func (l *lineIO) sendBlockData(blk block) (sendResult, error) {
 	l.sendBuf = blk.appendTo(l.sendBuf[:0])
 	if err := l.writeAll(l.sendBuf); err != nil {
@@ -293,7 +311,11 @@ func (l *lineIO) sendBlockData(blk block) (sendResult, error) {
 
 	b, err := l.readByte(l.timers().T2)
 	if err != nil {
-		return sendRetry, fmt.Errorf("%w: waiting for ACK: %w", ErrT2Timeout, err)
+		if isTimeout(err) {
+			return sendRetry, fmt.Errorf("%w: waiting for ACK: %w", ErrT2Timeout, err)
+		}
+
+		return sendAbort, fmt.Errorf("secs1: waiting for ACK: %w", err)
 	}
 
 	if b == ack {
@@ -323,7 +345,7 @@ func (l *lineIO) sendBlockData(blk block) (sendResult, error) {
 //
 // Returns:
 //   - error: nil on ACK; ErrSendFailed once the retries are exhausted; ctx.Err() on cancellation; a
-//     wrapped write error (non-retryable) otherwise. A deliver error during a contention yield is
+//     wrapped I/O error (non-retryable) otherwise. A deliver error during a contention yield is
 //     NON-FATAL (it never fails the send) — see the sendContention branch.
 func (l *lineIO) sendBlock(ctx context.Context, blk block, retryLimit int, deliver func(block) error) error {
 	retry := 0
@@ -354,8 +376,15 @@ func (l *lineIO) sendBlock(ctx context.Context, blk block, retryLimit int, deliv
 
 			recv, rerr := l.receiveBlock(ctx)
 			if rerr != nil {
-				// Anti-starvation (§7.8.2.1): a failed receive of the master's block is a normal
-				// retry — do NOT reset the counter and do NOT deliver.
+				if !errors.Is(rerr, ErrT1Timeout) &&
+					!errors.Is(rerr, ErrT2Timeout) &&
+					!errors.Is(rerr, ErrInvalidLength) &&
+					!errors.Is(rerr, ErrChecksumMismatch) {
+					return rerr
+				}
+
+				// Anti-starvation (§7.8.2.1): a timeout or protocol failure while receiving the
+				// master's block is a normal retry. Do not reset the counter or deliver.
 				l.metrics.incBlockRetryCount()
 				retry++
 

--- a/secs1/line_test.go
+++ b/secs1/line_test.go
@@ -7,8 +7,10 @@ package secs1
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -101,6 +103,59 @@ func makeTestBlock(t *testing.T, body []byte) block {
 
 	return block{header: buildHeader(h, 1, true), body: chunk}
 }
+
+type scriptedRead struct {
+	data []byte
+	err  error
+}
+
+type scriptedConn struct {
+	reads         []scriptedRead
+	writeErr      error
+	writeHook     func([]byte)
+	writeAttempts [][]byte
+}
+
+func (c *scriptedConn) Read(p []byte) (int, error) {
+	if len(c.reads) == 0 {
+		return 0, io.EOF
+	}
+
+	step := &c.reads[0]
+	n := copy(p, step.data)
+	if n < len(step.data) {
+		step.data = step.data[n:]
+
+		return n, nil
+	}
+
+	err := step.err
+	c.reads = c.reads[1:]
+
+	return n, err
+}
+
+func (c *scriptedConn) Write(p []byte) (int, error) {
+	attempt := append([]byte(nil), p...)
+	c.writeAttempts = append(c.writeAttempts, attempt)
+	if c.writeHook != nil {
+		c.writeHook(attempt)
+	}
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
+
+	return len(p), nil
+}
+
+func (*scriptedConn) Close() error                     { return nil }
+func (*scriptedConn) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (*scriptedConn) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (*scriptedConn) SetDeadline(time.Time) error      { return nil }
+func (*scriptedConn) SetReadDeadline(time.Time) error  { return nil }
+func (*scriptedConn) SetWriteDeadline(time.Time) error { return nil }
+
+var _ net.Conn = (*scriptedConn)(nil)
 
 // --- receiveBlock ---
 
@@ -208,6 +263,92 @@ func TestLineReceiveBlock_T1MidBlockTimeout(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrT1Timeout)
 	require.Equal(t, []byte{nak}, <-nakCh)
+}
+
+func TestLineReceiveBlock_LengthIOError(t *testing.T) {
+	readErr := errors.New("length read failed")
+	cfg := newLineTestConfig(t)
+	conn := &scriptedConn{reads: []scriptedRead{{err: readErr}}}
+	line := newLineIO(conn, cfg, cfg.Timers, &ConnectionMetrics{})
+
+	_, err := line.receiveBlock(t.Context())
+	require.ErrorIs(t, err, readErr)
+	require.NotErrorIs(t, err, ErrT1Timeout)
+	require.NotErrorIs(t, err, ErrT2Timeout)
+	require.Empty(t, conn.writeAttempts)
+	require.Zero(t, line.metrics.BlockNAKSentCount())
+}
+
+func TestLineReceiveBlock_MidBodyIOError(t *testing.T) {
+	readErr := errors.New("body read failed")
+	cfg := newLineTestConfig(t)
+	conn := &scriptedConn{reads: []scriptedRead{
+		{data: []byte{minBlockLength}},
+		{data: []byte{0x01}, err: readErr},
+	}}
+	line := newLineIO(conn, cfg, cfg.Timers, &ConnectionMetrics{})
+
+	_, err := line.receiveBlock(t.Context())
+	require.ErrorIs(t, err, readErr)
+	require.NotErrorIs(t, err, ErrT1Timeout)
+	require.NotErrorIs(t, err, ErrT2Timeout)
+	require.Empty(t, conn.writeAttempts)
+	require.Zero(t, line.metrics.BlockNAKSentCount())
+}
+
+func TestLineReceiveBlock_NAKWriteFailure(t *testing.T) {
+	nakWriteErr := errors.New("NAK write failed")
+	badChecksum := makeTestBlock(t, []byte("bad checksum")).appendTo(nil)
+	badChecksum[len(badChecksum)-1] ^= 0xFF
+
+	tests := []struct {
+		name    string
+		reads   []scriptedRead
+		wantErr error
+	}{
+		{
+			name:    "T2 length timeout",
+			reads:   []scriptedRead{{err: os.ErrDeadlineExceeded}},
+			wantErr: ErrT2Timeout,
+		},
+		{
+			name: "T1 body timeout",
+			reads: []scriptedRead{
+				{data: []byte{minBlockLength}},
+				{data: []byte{0x01}, err: os.ErrDeadlineExceeded},
+			},
+			wantErr: ErrT1Timeout,
+		},
+		{
+			name: "invalid length",
+			reads: []scriptedRead{
+				{data: []byte{minBlockLength - 1}},
+				{err: os.ErrDeadlineExceeded},
+			},
+			wantErr: ErrInvalidLength,
+		},
+		{
+			name: "checksum mismatch",
+			reads: []scriptedRead{
+				{data: badChecksum},
+				{err: os.ErrDeadlineExceeded},
+			},
+			wantErr: ErrChecksumMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &scriptedConn{reads: tt.reads, writeErr: nakWriteErr}
+			cfg := newLineTestConfig(t)
+			line := newLineIO(conn, cfg, cfg.Timers, &ConnectionMetrics{})
+
+			_, err := line.receiveBlock(t.Context())
+			require.ErrorIs(t, err, tt.wantErr)
+			require.Equal(t, [][]byte{{nak}}, conn.writeAttempts)
+			require.Zero(t, line.metrics.BlockNAKSentCount())
+		})
+	}
 }
 
 func TestLineReceiveBlock_CtxCancelled(t *testing.T) {
@@ -353,4 +494,142 @@ func TestLineSendBlockOnce_CtxCancelled(t *testing.T) {
 	res, err := line.sendBlockOnce(ctx, makeTestBlock(t, nil))
 	require.ErrorIs(t, err, context.Canceled)
 	require.Equal(t, sendAbort, res)
+}
+
+func TestLineSendBlockOnce_IOErrorsAbort(t *testing.T) {
+	tests := []struct {
+		name     string
+		closeACK bool
+	}{
+		{name: "waiting for EOT"},
+		{name: "waiting for ACK", closeACK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newLineTestConfig(t)
+			line, peer := newLinePair(t, cfg)
+			out := makeTestBlock(t, nil)
+			outWire := out.appendTo(nil)
+
+			peerDone := make(chan struct{})
+			go func() {
+				defer close(peerDone)
+				peerReadN(t, peer, 1)
+				if tt.closeACK {
+					peerWrite(t, peer, []byte{eot})
+					peerReadN(t, peer, len(outWire))
+				}
+				_ = peer.Close()
+			}()
+
+			result, err := line.sendBlockOnce(t.Context(), out)
+			<-peerDone
+			require.Equal(t, sendAbort, result)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, ErrT2Timeout)
+		})
+	}
+}
+
+func TestLineSendBlock_IOErrorsDoNotRetry(t *testing.T) {
+	tests := []struct {
+		name     string
+		closeACK bool
+	}{
+		{name: "waiting for EOT"},
+		{name: "waiting for ACK", closeACK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newLineTestConfig(t)
+			line, peer := newLinePair(t, cfg)
+			out := makeTestBlock(t, nil)
+			outWire := out.appendTo(nil)
+
+			peerDone := make(chan struct{})
+			go func() {
+				defer close(peerDone)
+				peerReadN(t, peer, 1)
+				if tt.closeACK {
+					peerWrite(t, peer, []byte{eot})
+					peerReadN(t, peer, len(outWire))
+				}
+				_ = peer.Close()
+			}()
+
+			err := line.sendBlock(t.Context(), out, cfg.RetryLimit(), failDeliver(t))
+			<-peerDone
+			require.Error(t, err)
+			require.NotErrorIs(t, err, ErrT2Timeout)
+			require.Zero(t, line.metrics.BlockRetryCount())
+		})
+	}
+}
+
+func TestLineSendBlock_ContentionYieldIOErrorAborts(t *testing.T) {
+	readErr := errors.New("contention receive failed")
+	cfg := newLineTestConfig(t)
+	conn := &scriptedConn{reads: []scriptedRead{
+		{data: []byte{enq}},
+		{err: readErr},
+	}}
+	line := newLineIO(conn, cfg, cfg.Timers, &ConnectionMetrics{})
+
+	err := line.sendBlock(t.Context(), makeTestBlock(t, nil), cfg.RetryLimit(), failDeliver(t))
+	require.ErrorIs(t, err, readErr)
+	require.Equal(t, [][]byte{{enq}, {eot}}, conn.writeAttempts)
+	require.Zero(t, line.metrics.BlockRetryCount())
+}
+
+func TestLineSendBlock_ContentionYieldCancellationAborts(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	conn := &scriptedConn{reads: []scriptedRead{{data: []byte{enq}}}}
+	conn.writeHook = func(p []byte) {
+		if len(p) == 1 && p[0] == eot {
+			cancel()
+		}
+	}
+	cfg := newLineTestConfig(t)
+	line := newLineIO(conn, cfg, cfg.Timers, &ConnectionMetrics{})
+
+	err := line.sendBlock(ctx, makeTestBlock(t, nil), cfg.RetryLimit(), failDeliver(t))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, [][]byte{{enq}, {eot}}, conn.writeAttempts)
+	require.Zero(t, line.metrics.BlockRetryCount())
+}
+
+func TestLineSendBlock_ContentionYieldRetryableFailures(t *testing.T) {
+	tests := []struct {
+		name  string
+		reads []scriptedRead
+	}{
+		{
+			name:  "T2 timeout",
+			reads: []scriptedRead{{data: []byte{enq}}, {err: os.ErrDeadlineExceeded}},
+		},
+		{
+			name: "invalid length",
+			reads: []scriptedRead{
+				{data: []byte{enq}},
+				{data: []byte{minBlockLength - 1}},
+				{err: os.ErrDeadlineExceeded},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newLineTestConfig(t)
+			conn := &scriptedConn{reads: tt.reads}
+			line := newLineIO(conn, cfg, cfg.Timers, &ConnectionMetrics{})
+
+			err := line.sendBlock(t.Context(), makeTestBlock(t, nil), 0, failDeliver(t))
+			require.ErrorIs(t, err, ErrSendFailed)
+			require.Equal(t, [][]byte{{enq}, {eot}, {nak}}, conn.writeAttempts)
+			require.Equal(t, uint64(1), line.metrics.BlockRetryCount())
+			require.Equal(t, uint64(1), line.metrics.BlockNAKSentCount())
+		})
+	}
 }

--- a/secs1/transport.go
+++ b/secs1/transport.go
@@ -552,10 +552,10 @@ func (t *transport) lineEngine(engineCtx context.Context, g *genWG, conn net.Con
 
 			blk, rerr := line.receiveBlock(engineCtx)
 			if rerr != nil {
-				// A block-level receive error (T1/T2 timeout, bad length/checksum) was already NAK'd by
-				// receiveBlock; the peer will RTY. This is NOT a link teardown — keep looping. Exit
-				// promptly, though, if the error is a teardown cancellation (a genuine conn close
-				// otherwise surfaces as the next poll's real read error → the (3) TCPDown path).
+				// A protocol or timeout receive error was already NAK'd by receiveBlock;
+				// the peer will RTY.
+				// A real I/O error is not NAK'd and surfaces again on the next poll's TCPDown path.
+				// Exit promptly if this generation is already tearing down.
 				if engineCtx.Err() != nil {
 					return
 				}
@@ -717,9 +717,15 @@ func (t *transport) ArmStart() {
 //
 // It is the SOLE producer on sendReqCh.
 //
-// ctx is intentionally NOT selected on. secs1 forces writeTimeout=0 (D5b-11), so the core arms no write deadline:
-// a SECS-I Write may legitimately block for a whole line transaction (T2 x (RetryLimit+1)).
-// The engine bounds that transaction, and teardown (genDone) is the release for a parked Write —
+// ctx is intentionally NOT selected on.
+// secs1 forces writeTimeout=0 (D5b-11), so the core arms no write deadline.
+// T2 bounds waits for protocol responses, and RetryLimit bounds the number of failed protocol retries.
+// Neither bounds socket writes; the line engine performs them without a write deadline.
+// Each successful slave contention yield restarts the postponed send as a fresh request under E4,
+// so repeated successful master traffic can postpone the local send until the generation ends.
+// A malformed block received during a contention yield is drained until T1 silence;
+// each arriving chunk restarts T1, so the peer can keep that drain active until teardown.
+// Close or connection teardown closes the socket to interrupt line I/O and closes genDone to release a parked Write;
 // ctx cancellation is not a SECS-I line-abort signal.
 //
 // Shape + control guard (P0-2): the core supplies bufs whose bufs[0] is a 14-byte prefix ([4-byte length][10-byte HSMS header])
@@ -778,28 +784,11 @@ func (t *transport) Write(_ context.Context, conn net.Conn, bufs net.Buffers) er
 	}
 }
 
-// SetReadDeadline sets the read deadline on conn — the epoch's socket, passed explicitly (never re-resolve t.conn).
-//
-// Conn-bound no-op today: the line engine arms its own read deadlines on its captured conn (linePollInterval poll, T1/T2 in receiveBlock),
-// so no core caller drives this.
-func (t *transport) SetReadDeadline(conn net.Conn, deadline time.Time) error {
-	if conn == nil {
-		return nil
-	}
+// SetReadDeadline is a no-op because the line engine exclusively owns socket deadlines.
+func (t *transport) SetReadDeadline(_ net.Conn, _ time.Time) error { return nil }
 
-	return conn.SetReadDeadline(deadline)
-}
-
-// SetWriteDeadline sets the write deadline on conn — the same epoch socket handed to Write.
-//
-// Conn-bound no-op today: the line engine owns all writes on its captured conn.
-func (t *transport) SetWriteDeadline(conn net.Conn, deadline time.Time) error {
-	if conn == nil {
-		return nil
-	}
-
-	return conn.SetWriteDeadline(deadline)
-}
+// SetWriteDeadline is a no-op because the line engine exclusively owns socket deadlines.
+func (t *transport) SetWriteDeadline(_ net.Conn, _ time.Time) error { return nil }
 
 // applyKeepAlive enables TCP keep-alive probes on conn when TCPKeepAlive > 0 in the config. conn is
 // typically a *net.TCPConn (the passive Accept result or the default dialer's socket); a custom

--- a/secs1/transport_test.go
+++ b/secs1/transport_test.go
@@ -59,6 +59,24 @@ type mockRuntime struct {
 // implement it — all method params are exported types).
 var _ hsms.TransportRuntime = (*mockRuntime)(nil)
 
+type deadlineCallConn struct {
+	net.Conn
+	readDeadlineCalls  int
+	writeDeadlineCalls int
+}
+
+func (c *deadlineCallConn) SetReadDeadline(deadline time.Time) error {
+	c.readDeadlineCalls++
+
+	return c.Conn.SetReadDeadline(deadline)
+}
+
+func (c *deadlineCallConn) SetWriteDeadline(deadline time.Time) error {
+	c.writeDeadlineCalls++
+
+	return c.Conn.SetWriteDeadline(deadline)
+}
+
 func newMockRuntime() *mockRuntime {
 	m := &mockRuntime{
 		tcpDownCh: make(chan struct{}),
@@ -333,6 +351,20 @@ func TestTransport_ArmStartInstallsFreshBundleAndChannels(t *testing.T) {
 	require.NotSame(t, wg1, tr.wg, "each ArmStart must install a fresh genWG — no cross-generation reuse")
 	require.True(t, tr.genDone != done1, "each ArmStart must install a fresh genDone — no cross-generation reuse")
 	require.True(t, tr.sendReqCh != sr1, "each ArmStart must install a fresh sendReqCh — no cross-generation reuse")
+}
+
+func TestTransport_DeadlineHooksAreNoOps(t *testing.T) {
+	local, peer := net.Pipe()
+	t.Cleanup(func() { _ = local.Close() })
+	t.Cleanup(func() { _ = peer.Close() })
+
+	conn := &deadlineCallConn{Conn: local}
+	tr := &transport{}
+
+	require.NoError(t, tr.SetReadDeadline(conn, time.Now()))
+	require.NoError(t, tr.SetWriteDeadline(conn, time.Now()))
+	require.Zero(t, conn.readDeadlineCalls)
+	require.Zero(t, conn.writeDeadlineCalls)
 }
 
 // --- Engine send path (runSend via sendReqCh) + the G-C cap-1 done invariant ---

--- a/secs2/cursor.go
+++ b/secs2/cursor.go
@@ -12,8 +12,9 @@ import (
 //	v, err := secs2.NewCursor(item).At(1, 0).ASCII()
 //
 // A Cursor is created with [NewCursor].
-// Copying it is free — it is a plain value with no pointer to mutable state — and no method
-// allocates on the happy path.
+// Copying it is free because it is a plain value with no pointer to mutable state.
+// Navigation and non-copying terminal accessors allocate nothing on the happy path;
+// [Cursor.Binary] allocates its documented caller-owned copy.
 //
 // Navigation with [Cursor.At] accumulates errors instead of failing immediately: once a hop
 // fails, every later [Cursor.At] call on the resulting Cursor is a no-op, and the terminal
@@ -30,7 +31,7 @@ type Cursor struct {
 //
 // A nil item yields a Cursor whose accessors all return a descriptive error; it never panics.
 func NewCursor(item Item) Cursor {
-	if item == nil {
+	if isNilItem(item) {
 		return Cursor{err: errors.New("secs2: cursor: item is nil")}
 	}
 
@@ -75,6 +76,10 @@ func (c Cursor) At(indices ...int) Cursor {
 	index := c.index
 
 	for _, idx := range indices {
+		if isNilItem(cur) {
+			return Cursor{err: fmt.Errorf("secs2: cursor at index %d (depth %d): item is nil", idx, depth)}
+		}
+
 		if !cur.IsList() {
 			return Cursor{err: hopTypeErr(idx, depth, cur.Type())}
 		}
@@ -82,6 +87,9 @@ func (c Cursor) At(indices ...int) Cursor {
 		next, err := cur.ItemAt(idx)
 		if err != nil {
 			return Cursor{err: fmt.Errorf("secs2: cursor at index %d (depth %d): %w", idx, depth, err)}
+		}
+		if isNilItem(next) {
+			return Cursor{err: fmt.Errorf("secs2: cursor at index %d (depth %d): item is nil", idx, depth)}
 		}
 
 		cur = next

--- a/secs2/cursor.go
+++ b/secs2/cursor.go
@@ -38,6 +38,28 @@ func NewCursor(item Item) Cursor {
 	return Cursor{item: item}
 }
 
+// fault reports why the cursor cannot be read, or nil when it can.
+//
+// It folds the two conditions every terminal accessor must reject:
+// an error already accumulated by [NewCursor] or by a failed [Cursor.At] hop,
+// and the zero-value Cursor.
+//
+// Cursor is an exported struct, so a consumer reaches its zero value without calling NewCursor —
+// through a struct field left unset, a var assigned on only one branch, or a map lookup that misses.
+// That value carries a nil item and a nil error,
+// and without this guard the accessors dereference the nil item while formatting a mismatch error.
+func (c Cursor) fault() error {
+	if c.err != nil {
+		return c.err
+	}
+
+	if isNilItem(c.item) {
+		return errors.New("secs2: cursor: zero-value Cursor; construct one with NewCursor")
+	}
+
+	return nil
+}
+
 // hopTypeErr reports that [Cursor.At] tried to navigate a list index into an item that is not a
 // list. idx and depth describe the hop that failed: idx is the index being navigated, depth is
 // the number of hops that succeeded before it.
@@ -76,6 +98,9 @@ func (c Cursor) At(indices ...int) Cursor {
 	index := c.index
 
 	for _, idx := range indices {
+		// Not redundant: NewCursor validates its item and the hop below validates each next,
+		// but Cursor is an exported struct, so a consumer's zero value arrives here with a nil item and no error.
+		// Removing this guard makes Cursor{}.At(0) panic.
 		if isNilItem(cur) {
 			return Cursor{err: fmt.Errorf("secs2: cursor at index %d (depth %d): item is nil", idx, depth)}
 		}
@@ -108,8 +133,8 @@ func (c Cursor) At(indices ...int) Cursor {
 // Returns an error if the cursor already carries one, the item is not a UintItem, the item
 // carries a deferred construction error, or its size is not 1.
 func (c Cursor) Uint() (uint64, error) {
-	if c.err != nil {
-		return 0, c.err
+	if err := c.fault(); err != nil {
+		return 0, err
 	}
 
 	item, ok := c.item.(*UintItem)
@@ -136,8 +161,8 @@ func (c Cursor) Uint() (uint64, error) {
 // Returns an error if the cursor already carries one, the item is not an IntItem, the item
 // carries a deferred construction error, or its size is not 1.
 func (c Cursor) Int() (int64, error) {
-	if c.err != nil {
-		return 0, c.err
+	if err := c.fault(); err != nil {
+		return 0, err
 	}
 
 	item, ok := c.item.(*IntItem)
@@ -163,8 +188,8 @@ func (c Cursor) Int() (int64, error) {
 // Returns an error if the cursor already carries one, the item is not a FloatItem, the item
 // carries a deferred construction error, or its size is not 1.
 func (c Cursor) Float() (float64, error) {
-	if c.err != nil {
-		return 0, c.err
+	if err := c.fault(); err != nil {
+		return 0, err
 	}
 
 	item, ok := c.item.(*FloatItem)
@@ -190,8 +215,8 @@ func (c Cursor) Float() (float64, error) {
 // Returns an error if the cursor already carries one, the item is not a BooleanItem, the item
 // carries a deferred construction error, or its size is not 1.
 func (c Cursor) Bool() (bool, error) {
-	if c.err != nil {
-		return false, c.err
+	if err := c.fault(); err != nil {
+		return false, err
 	}
 
 	item, ok := c.item.(*BooleanItem)
@@ -218,8 +243,8 @@ func (c Cursor) Bool() (bool, error) {
 // Returns an error if the cursor already carries one, the item is not an ASCIIItem, or the item
 // carries a deferred construction error.
 func (c Cursor) ASCII() (string, error) {
-	if c.err != nil {
-		return "", c.err
+	if err := c.fault(); err != nil {
+		return "", err
 	}
 
 	item, ok := c.item.(*ASCIIItem)
@@ -242,8 +267,8 @@ func (c Cursor) ASCII() (string, error) {
 // Returns an error if the cursor already carries one, the item is not a BinaryItem, or the item
 // carries a deferred construction error.
 func (c Cursor) Binary() ([]byte, error) {
-	if c.err != nil {
-		return nil, c.err
+	if err := c.fault(); err != nil {
+		return nil, err
 	}
 
 	item, ok := c.item.(*BinaryItem)
@@ -260,11 +285,11 @@ func (c Cursor) Binary() ([]byte, error) {
 
 // Size returns the [Item.Size] of the item at the cursor.
 //
-// It carries forward any error already on the cursor, but otherwise never fails: like
-// Item.Size, it does not consult the item's deferred construction error.
+// It carries forward any error already on the cursor, and otherwise fails only on a zero-value
+// Cursor: like Item.Size, it does not consult the item's deferred construction error.
 func (c Cursor) Size() (int, error) {
-	if c.err != nil {
-		return 0, c.err
+	if err := c.fault(); err != nil {
+		return 0, err
 	}
 
 	return c.item.Size(), nil
@@ -272,11 +297,12 @@ func (c Cursor) Size() (int, error) {
 
 // Item unwraps the cursor and returns the [Item] at its current position.
 //
-// It carries forward any error already on the cursor, but does not itself consult the returned
-// item's deferred construction error — call [Item.Error] on the result to check that.
+// It carries forward any error already on the cursor, including the zero-value Cursor's.
+// It does not itself consult the returned item's deferred construction error —
+// call [Item.Error] on the result to check that.
 func (c Cursor) Item() (Item, error) {
-	if c.err != nil {
-		return nil, c.err
+	if err := c.fault(); err != nil {
+		return nil, err
 	}
 
 	return c.item, nil

--- a/secs2/cursor.go
+++ b/secs2/cursor.go
@@ -285,8 +285,8 @@ func (c Cursor) Binary() ([]byte, error) {
 
 // Size returns the [Item.Size] of the item at the cursor.
 //
-// It carries forward any error already on the cursor, and otherwise fails only on a zero-value
-// Cursor: like Item.Size, it does not consult the item's deferred construction error.
+// It carries forward any error already on the cursor, and otherwise fails only on a zero-value Cursor:
+// like Item.Size, it does not consult the item's deferred construction error.
 func (c Cursor) Size() (int, error) {
 	if err := c.fault(); err != nil {
 		return 0, err
@@ -297,7 +297,7 @@ func (c Cursor) Size() (int, error) {
 
 // Item unwraps the cursor and returns the [Item] at its current position.
 //
-// It carries forward any error already on the cursor, including the zero-value Cursor's.
+// It carries forward any error already on the cursor, and reports a zero-value Cursor as an error of its own.
 // It does not itself consult the returned item's deferred construction error —
 // call [Item.Error] on the result to check that.
 func (c Cursor) Item() (Item, error) {
@@ -310,6 +310,7 @@ func (c Cursor) Item() (Item, error) {
 
 // Err returns the first error encountered while navigating or reading through the cursor, or nil
 // if none occurred.
+// A zero-value Cursor reports no error here, but every terminal accessor rejects it.
 func (c Cursor) Err() error {
 	return c.err
 }

--- a/secs2/cursor_test.go
+++ b/secs2/cursor_test.go
@@ -27,6 +27,42 @@ func cursorTree() Item {
 	)
 }
 
+type externalNilItem struct {
+	Item
+}
+
+var _ Item = (*externalNilItem)(nil)
+
+func requireCursorAccessorsError(t *testing.T, c Cursor) {
+	t.Helper()
+
+	require.Error(t, c.Err())
+
+	_, err := c.Uint()
+	require.Error(t, err)
+
+	_, err = c.Int()
+	require.Error(t, err)
+
+	_, err = c.Float()
+	require.Error(t, err)
+
+	_, err = c.Bool()
+	require.Error(t, err)
+
+	_, err = c.ASCII()
+	require.Error(t, err)
+
+	_, err = c.Binary()
+	require.Error(t, err)
+
+	_, err = c.Size()
+	require.Error(t, err)
+
+	_, err = c.Item()
+	require.Error(t, err)
+}
+
 func TestNewCursor_NilItem(t *testing.T) {
 	t.Parallel()
 
@@ -62,6 +98,39 @@ func TestNewCursor_NilItem(t *testing.T) {
 	// At on an errored cursor is a no-op.
 	c2 := c.At(0)
 	require.ErrorIs(t, c2.Err(), c.Err())
+}
+
+func TestNewCursor_TypedNilBuiltins(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range builtinTypeChildren() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			requireCursorAccessorsError(t, NewCursor(tt.nilv))
+		})
+	}
+}
+
+func TestNewCursor_ExternalTypedNil(t *testing.T) {
+	t.Parallel()
+
+	var item *externalNilItem
+	requireCursorAccessorsError(t, NewCursor(item))
+}
+
+func TestCursor_HappyPathAllocs(t *testing.T) {
+	root := L(L(U1(uint(7))))
+	var value uint64
+	var err error
+
+	allocs := testing.AllocsPerRun(100, func() {
+		value, err = NewCursor(root).At(0, 0).Uint()
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), value)
+	require.Zero(t, allocs)
 }
 
 func TestCursor_Uint_Widths(t *testing.T) {
@@ -259,6 +328,20 @@ func TestCursor_At_NonListIntermediate(t *testing.T) {
 	require.ErrorContains(t, err, "depth 1")
 	require.ErrorContains(t, err, "got ascii")
 	require.ErrorContains(t, err, "want list")
+}
+
+func TestCursor_At_TypedNilChild(t *testing.T) {
+	t.Parallel()
+
+	var child *ASCIIItem
+	builtin := NewListItem(child)
+	external := &externalListItem{
+		Item:     NewListItem(),
+		children: []Item{builtin},
+	}
+	root := NewListItem(external)
+
+	requireCursorAccessorsError(t, NewCursor(root).At(0, 0, 0))
 }
 
 func TestCursor_WrongTypeFamily(t *testing.T) {

--- a/secs2/cursor_test.go
+++ b/secs2/cursor_test.go
@@ -302,6 +302,93 @@ func TestCursor_At_NoIndices(t *testing.T) {
 	require.Same(t, root, item)
 }
 
+// TestCursor_ZeroValue asserts that a zero-value Cursor never panics from any of its eleven surfaces,
+// even though it is reachable without calling NewCursor since Cursor is an exported struct.
+// It also asserts that every surface other than Err and the no-index form of At reports a
+// non-nil error.
+//
+// The "At(0)" case also pins the in-loop isNilItem guard inside At's loop (see the comment there):
+// deleting that guard turns Cursor{}.At(0) into a nil-interface panic instead of a descriptive error,
+// so a later reader who concludes the guard is dead has a failing test to correct them.
+func TestCursor_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{"Err", func(t *testing.T) {
+			var c Cursor
+			require.NotPanics(t, func() { _ = c.Err() })
+		}},
+		{"At(0)", func(t *testing.T) {
+			var c Cursor
+			var next Cursor
+			require.NotPanics(t, func() { next = c.At(0) })
+			require.Error(t, next.Err())
+		}},
+		{"At()", func(t *testing.T) {
+			var c Cursor
+			require.NotPanics(t, func() { c.At() })
+		}},
+		{"Uint", func(t *testing.T) {
+			var c Cursor
+			var err error
+			require.NotPanics(t, func() { _, err = c.Uint() })
+			require.Error(t, err)
+		}},
+		{"Int", func(t *testing.T) {
+			var c Cursor
+			var err error
+			require.NotPanics(t, func() { _, err = c.Int() })
+			require.Error(t, err)
+		}},
+		{"Float", func(t *testing.T) {
+			var c Cursor
+			var err error
+			require.NotPanics(t, func() { _, err = c.Float() })
+			require.Error(t, err)
+		}},
+		{"Bool", func(t *testing.T) {
+			var c Cursor
+			var err error
+			require.NotPanics(t, func() { _, err = c.Bool() })
+			require.Error(t, err)
+		}},
+		{"ASCII", func(t *testing.T) {
+			var c Cursor
+			var err error
+			require.NotPanics(t, func() { _, err = c.ASCII() })
+			require.Error(t, err)
+		}},
+		{"Binary", func(t *testing.T) {
+			var c Cursor
+			var err error
+			require.NotPanics(t, func() { _, err = c.Binary() })
+			require.Error(t, err)
+		}},
+		{"Size", func(t *testing.T) {
+			var c Cursor
+			var err error
+			require.NotPanics(t, func() { _, err = c.Size() })
+			require.Error(t, err)
+		}},
+		{"Item", func(t *testing.T) {
+			var c Cursor
+			var err error
+			require.NotPanics(t, func() { _, err = c.Item() })
+			require.Error(t, err)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.run(t)
+		})
+	}
+}
+
 // --- Failure classes ---
 
 func TestCursor_At_IndexOutOfRange(t *testing.T) {

--- a/secs2/equal.go
+++ b/secs2/equal.go
@@ -16,7 +16,7 @@ import (
 //
 // An item carrying a deferred construction error (Error() != nil) is never equal to any item, including another errored item, because its logical value is unspecified.
 //
-// Two nil items are equal; a nil item is not equal to a non-nil item.
+// Two nil-like items are equal; a nil-like item is not equal to a non-nil item.
 //
 // Parameters:
 //   - a: the first item to compare.
@@ -25,8 +25,9 @@ import (
 // Returns:
 //   - bool: true if a and b are the same SECS-II item.
 func Equal(a, b Item) bool {
-	if a == nil || b == nil {
-		return a == nil && b == nil
+	aNil, bNil := isNilItem(a), isNilItem(b)
+	if aNil || bNil {
+		return aNil && bNil
 	}
 	if a.Error() != nil || b.Error() != nil {
 		return false

--- a/secs2/equal_test.go
+++ b/secs2/equal_test.go
@@ -32,6 +32,39 @@ func TestEqual_NilHandling(t *testing.T) {
 	assert.False(t, Equal(I1(5), nil))
 }
 
+func TestEqual_TypedNilHandling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		item Item
+	}{
+		{name: "built-in pointer", item: (*ASCIIItem)(nil)},
+		{name: "external pointer", item: (*fakeItem)(nil)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var itemNil, nilItem, itemItem, itemValid, validItem bool
+			require.NotPanics(t, func() {
+				itemNil = Equal(tt.item, nil)
+				nilItem = Equal(nil, tt.item)
+				itemItem = Equal(tt.item, tt.item)
+				itemValid = Equal(tt.item, I1(5))
+				validItem = Equal(I1(5), tt.item)
+			})
+
+			assert.True(t, itemNil)
+			assert.True(t, nilItem)
+			assert.True(t, itemItem)
+			assert.False(t, itemValid)
+			assert.False(t, validItem)
+		})
+	}
+}
+
 func TestEqual_ErroredItemNeverEqual(t *testing.T) {
 	t.Parallel()
 

--- a/secs2/item.go
+++ b/secs2/item.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"reflect"
 	"unsafe"
 )
 
@@ -112,12 +113,30 @@ func NewItemErrorWithMsg(errMsg string) *ItemError {
 //
 // If err is already an ItemError, the inner error is unwrapped to avoid double-wrapping.
 func NewItemError(err error) *ItemError {
+	if err == nil {
+		err = errors.New("secs2: nil error")
+	}
+
 	itemErr := &ItemError{}
 	if errors.As(err, &itemErr) {
 		return &ItemError{err: errors.Unwrap(err)}
 	}
 
 	return &ItemError{err: err}
+}
+
+func isNilItem(item Item) bool {
+	if item == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(item)
+	switch v.Kind() { //nolint:exhaustive // only nil-capable kinds may call Value.IsNil
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
 }
 
 // Error implements the error interface.

--- a/secs2/item_test.go
+++ b/secs2/item_test.go
@@ -471,6 +471,15 @@ func TestNewItemError(t *testing.T) {
 	}
 }
 
+func TestNewItemError_Nil(t *testing.T) {
+	t.Parallel()
+
+	err := NewItemError(nil)
+	require.NotPanics(t, func() { _ = err.Error() })
+	require.Error(t, err.Unwrap())
+	require.Equal(t, "secs2: nil error", err.Error())
+}
+
 // TestNewItemError_deferredErrorSurface proves the wrap chain stays errors.Is-transparent all the
 // way from a concrete item's deferred error to the original sentinel, through baseItem.setError's
 // errors.Join + NewItemError path.

--- a/secs2/list.go
+++ b/secs2/list.go
@@ -226,7 +226,8 @@ func (item *ListItem) Error() error {
 
 // EncodedLen returns the total SECS-II wire byte length: the list header (whose data-length field encodes the child count) plus the sum of each child's EncodedLen.
 //
-// Returns 0 when the list or any child has a deferred construction error.
+// Returns 0 when [ListItem.Error] reports a non-nil error:
+// a deferred construction error on the list or any child, a nil child, or an empty item used as a child.
 func (item *ListItem) EncodedLen() int {
 	if !item.clean && item.Error() != nil {
 		return 0
@@ -248,7 +249,8 @@ func (item *ListItem) EncodedLen() int {
 // AppendTo appends the SECS-II wire encoding of this list (header + recursively encoded children) into dst
 // and returns the extended slice.
 //
-// Returns dst unchanged when the list or any child has a deferred construction error.
+// Returns dst unchanged when [ListItem.Error] reports a non-nil error:
+// a deferred construction error on the list or any child, a nil child, or an empty item used as a child.
 func (item *ListItem) AppendTo(dst []byte) []byte {
 	if !item.clean && item.Error() != nil {
 		return dst

--- a/secs2/list.go
+++ b/secs2/list.go
@@ -228,7 +228,7 @@ func (item *ListItem) Error() error {
 //
 // Returns 0 when the list or any child has a deferred construction error.
 func (item *ListItem) EncodedLen() int {
-	if item.Error() != nil {
+	if !item.clean && item.Error() != nil {
 		return 0
 	}
 
@@ -250,7 +250,7 @@ func (item *ListItem) EncodedLen() int {
 //
 // Returns dst unchanged when the list or any child has a deferred construction error.
 func (item *ListItem) AppendTo(dst []byte) []byte {
-	if item.Error() != nil {
+	if !item.clean && item.Error() != nil {
 		return dst
 	}
 

--- a/secs2/list.go
+++ b/secs2/list.go
@@ -93,7 +93,7 @@ func childClean(v Item) bool { //nolint:cyclop // one type-switch arm per built-
 	case *LocalizedStrItem:
 		return t != nil && t.itemErr == nil
 	case *EmptyItem:
-		return t != nil && t.itemErr == nil
+		return false
 	case *ListItem:
 		return t != nil && t.itemErr == nil && t.clean
 	default:
@@ -106,6 +106,10 @@ func childClean(v Item) bool { //nolint:cyclop // one type-switch arm per built-
 // With no indices it returns the list itself.
 // Returns an error if any intermediate item is not a list or if an index is out of range.
 func (item *ListItem) Get(indices ...int) (Item, error) {
+	if isNilItem(item) {
+		return nil, errors.New("failed to get nested item")
+	}
+
 	if len(indices) == 0 {
 		return item, nil
 	}
@@ -113,17 +117,16 @@ func (item *ListItem) Get(indices ...int) (Item, error) {
 	var cur Item = item
 
 	for _, idx := range indices {
-		if !cur.IsList() {
+		if isNilItem(cur) || !cur.IsList() {
 			return nil, errors.New("failed to get nested item")
 		}
 
-		li, _ := cur.(*ListItem)
-
-		if idx < 0 || idx >= li.Size() {
+		next, err := cur.ItemAt(idx)
+		if err != nil || isNilItem(next) {
 			return nil, errors.New("failed to get nested item")
 		}
 
-		cur = li.values[idx]
+		cur = next
 	}
 
 	return cur, nil
@@ -204,9 +207,18 @@ func (item *ListItem) Error() error {
 	}
 
 	for _, v := range item.values {
-		if v != nil {
-			errs = errors.Join(errs, v.Error())
+		if isNilItem(v) {
+			errs = errors.Join(errs, errors.New("secs2: list contains nil item"))
+
+			continue
 		}
+		if v.IsEmpty() {
+			errs = errors.Join(errs, NewItemErrorWithMsg("secs2: empty item is not valid as a list child"))
+
+			continue
+		}
+
+		errs = errors.Join(errs, v.Error())
 	}
 
 	return errs
@@ -214,9 +226,9 @@ func (item *ListItem) Error() error {
 
 // EncodedLen returns the total SECS-II wire byte length: the list header (whose data-length field encodes the child count) plus the sum of each child's EncodedLen.
 //
-// Returns 0 for items with a deferred construction error.
+// Returns 0 when the list or any child has a deferred construction error.
 func (item *ListItem) EncodedLen() int {
-	if item.itemErr != nil {
+	if item.Error() != nil {
 		return 0
 	}
 
@@ -236,9 +248,9 @@ func (item *ListItem) EncodedLen() int {
 // AppendTo appends the SECS-II wire encoding of this list (header + recursively encoded children) into dst
 // and returns the extended slice.
 //
-// Returns dst unchanged for items with a deferred construction error.
+// Returns dst unchanged when the list or any child has a deferred construction error.
 func (item *ListItem) AppendTo(dst []byte) []byte {
-	if item.itemErr != nil {
+	if item.Error() != nil {
 		return dst
 	}
 
@@ -264,13 +276,16 @@ func (item *ListItem) ToBytes() []byte {
 
 // ToSML returns the SML (SECS Message Language) text representation of this list, with nested items indented by two spaces per level.
 func (item *ListItem) ToSML() string {
-	return item.formatSML(0)
+	return formatListSML(item, 0)
 }
 
-// formatSML returns the indented SML representation of this list at the given indent level.
-// Each level adds 2 spaces of prefix to child lines. itemErr is intentionally not guarded
-// here (template pattern): an error list with no children renders as <L[0]>.
-func (item *ListItem) formatSML(level int) string {
+// formatListSML returns the indented SML representation of a list at the given indent level.
+// Each level adds 2 spaces of prefix to child lines.
+func formatListSML(item Item, level int) string {
+	if isNilItem(item) || !item.IsList() || item.Error() != nil {
+		return ""
+	}
+
 	indentStr := strings.Repeat("  ", level)
 
 	if item.Size() == 0 {
@@ -279,11 +294,21 @@ func (item *ListItem) formatSML(level int) string {
 
 	var sb strings.Builder
 
-	sb.Grow(len(item.values) * 20) //nolint:mnd
+	sb.Grow(item.Size() * 20) //nolint:mnd
 
-	for _, value := range item.values {
-		if v, ok := value.(*ListItem); ok {
-			sb.WriteString(v.formatSML(level + 1))
+	for i := range item.Size() {
+		value, err := item.ItemAt(i)
+		if err != nil || isNilItem(value) || value.Error() != nil {
+			return ""
+		}
+
+		if value.IsList() {
+			nested := formatListSML(value, level+1)
+			if nested == "" {
+				return ""
+			}
+
+			sb.WriteString(nested)
 			sb.WriteByte('\n')
 		} else {
 			sb.WriteString(indentStr)

--- a/secs2/list_test.go
+++ b/secs2/list_test.go
@@ -156,6 +156,43 @@ func TestListItem_Get(t *testing.T) {
 	require.Error(err)
 }
 
+type externalListItem struct {
+	Item
+	children []Item
+}
+
+var _ Item = (*externalListItem)(nil)
+
+func (e *externalListItem) IsList() bool { return true }
+
+func (e *externalListItem) Size() int { return len(e.children) }
+
+func (e *externalListItem) ItemAt(i int) (Item, error) {
+	if i < 0 || i >= len(e.children) {
+		return nil, NewItemErrorWithMsg("index out of range")
+	}
+
+	return e.children[i], nil
+}
+
+func TestListItem_Get_ExternalList(t *testing.T) {
+	t.Parallel()
+
+	want := NewASCIIItem("nested")
+	external := &externalListItem{
+		Item:     NewListItem(),
+		children: []Item{want},
+	}
+	list := NewListItem(external)
+
+	li, ok := list.(*ListItem)
+	require.True(t, ok)
+
+	got, err := li.Get(0, 0)
+	require.NoError(t, err)
+	require.Same(t, want, got)
+}
+
 // TestListItem_ToList_NoLeak confirms that mutating the slice returned by ToList does not
 // affect the ListItem's internal state (teeth test for the shallow-clone guarantee).
 func TestListItem_ToList_NoLeak(t *testing.T) {
@@ -262,6 +299,29 @@ func TestListItem_AppendTo_IndependentVector(t *testing.T) {
 	buf := make([]byte, 0, item.EncodedLen())
 	require.Equal(expected, item.AppendTo(buf))
 	require.Equal(expected, item.ToBytes())
+}
+
+func TestListItem_InvalidChildrenDoNotEncode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		item Item
+	}{
+		{name: "empty child", item: NewListItem(NewEmptyItem())},
+		{name: "errored child", item: NewListItem(NewIntItem(3, 1))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Error(t, tt.item.Error())
+			require.Zero(t, tt.item.EncodedLen())
+			require.Equal(t, []byte{0xAA}, tt.item.AppendTo([]byte{0xAA}))
+			require.Empty(t, tt.item.ToBytes())
+		})
+	}
 }
 
 // TestListItem_Error verifies that Error() aggregates errors from all children recursively,
@@ -490,13 +550,17 @@ func builtinTypeChildren() []builtinTypeChild {
 	}
 }
 
-// TestListItem_AllBuiltinTypes_Clean drives every built-in concrete type through NewListItem as
-// a single valid child and verifies the resulting list is known-clean: Error() returns nil, and
-// the internal clean flag is set (the O(1) fast path condition this task adds).
+// TestListItem_AllBuiltinTypes_Clean drives every wire-encodable built-in concrete type through
+// NewListItem as a single valid child and verifies the resulting list is known-clean.
+// EmptyItem is an absence sentinel rather than a wire-encodable child, so it is checked separately.
 func TestListItem_AllBuiltinTypes_Clean(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range builtinTypeChildren() {
+		if tt.valid.IsEmpty() {
+			continue
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -510,6 +574,13 @@ func TestListItem_AllBuiltinTypes_Clean(t *testing.T) {
 			require.True(li.clean, "list containing a single valid %s child must be known-clean", tt.name)
 		})
 	}
+
+	emptyChild := NewListItem(NewEmptyItem())
+	require.Error(t, emptyChild.Error())
+
+	li, ok := emptyChild.(*ListItem)
+	require.True(t, ok)
+	require.False(t, li.clean, "a list containing EmptyItem must not be known-clean")
 }
 
 // TestListItem_Clean_EmptyNilSkipDecoded verifies Error() == nil for an empty list, a list whose
@@ -570,12 +641,8 @@ func TestListItem_Clean_EmptyNilSkipDecoded(t *testing.T) {
 	})
 }
 
-// TestListItem_TypedNilBuiltinChild verifies that a typed-nil built-in pointer, wrapped as an
-// Item, is never silently skipped or mistaken for known-clean: NewListItem must not panic when
-// storing it (each type-switch arm in childClean nil-checks before reading itemErr), but
-// Error() must still panic when it reaches the typed nil, exactly as it did before this task —
-// only the known-clean fast path is new; the not-clean walk that dereferences the nil pointer
-// is untouched.
+// TestListItem_TypedNilBuiltinChild verifies that typed-nil built-in children remain stored but
+// make traversal and formatting fail closed instead of panicking.
 func TestListItem_TypedNilBuiltinChild(t *testing.T) {
 	t.Parallel()
 
@@ -583,24 +650,27 @@ func TestListItem_TypedNilBuiltinChild(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			require := require.New(t)
-
-			var list Item
-
-			require.NotPanics(func() {
-				list = NewListItem(NewASCIIItem("ok"), tt.nilv)
-			})
-			require.Equal(2, list.Size(), "typed-nil child must be stored, not skipped")
+			list := NewListItem(NewASCIIItem("ok"), tt.nilv)
+			require.Equal(t, 2, list.Size(), "typed-nil child must be stored, not skipped")
+			require.Error(t, list.Error())
 
 			li, ok := list.(*ListItem)
-			require.True(ok)
-			require.False(li.clean, "a typed-nil built-in child must never be known-clean")
+			require.True(t, ok)
 
-			require.Panics(func() {
-				_ = list.Error()
-			}, "Error() must still panic on a typed-nil built-in child, unchanged from before this task")
+			_, err := li.Get(1)
+			require.Error(t, err)
+			require.Empty(t, list.ToSML())
 		})
 	}
+}
+
+func TestListItem_ToSML_OwnErrorIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	item := &ListItem{}
+	item.itemErr = NewItemErrorWithMsg("boom")
+
+	require.Empty(t, item.ToSML())
 }
 
 // countingErrorItem is a minimal external Item implementation used to verify that the

--- a/secs2/message.go
+++ b/secs2/message.go
@@ -18,7 +18,8 @@ var _ SECS2Message = (*Message)(nil)
 // NewMessage creates a SECS2Message from the given stream and function codes, wait bit, and data item.
 //
 // When replyExpected is true the message's wait bit (W-bit) is set, indicating that a reply is expected from the receiver.
-// If item is nil it is replaced with NewEmptyItem, so the returned message always carries a valid, empty-bodied item.
+// If item is nil or a typed nil it is replaced with NewEmptyItem,
+// so the returned message always carries a valid, empty-bodied item.
 //
 // Parameters:
 //   - stream: the SECS-II stream code.
@@ -29,7 +30,7 @@ var _ SECS2Message = (*Message)(nil)
 // Returns:
 //   - SECS2Message: the constructed message.
 func NewMessage(stream, function byte, replyExpected bool, item Item) SECS2Message {
-	if item == nil {
+	if isNilItem(item) {
 		item = NewEmptyItem()
 	}
 

--- a/secs2/message_test.go
+++ b/secs2/message_test.go
@@ -58,3 +58,20 @@ func TestNewMessageNilItem(t *testing.T) {
 	require.NoError(err)
 	require.True(decoded.IsEmpty())
 }
+
+// TestNewMessageTypedNilItem verifies a typed-nil item -- an interface value that holds a nil
+// *ASCIIItem rather than being nil itself -- is caught by isNilItem and replaced the same as a
+// bare nil, so it never survives into Message.Item().
+func TestNewMessageTypedNilItem(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+
+	var item *ASCIIItem
+	msg := NewMessage(1, 1, false, item)
+
+	got := msg.Item()
+	require.NotNil(got)
+	require.True(got.IsEmpty())
+	require.NotPanics(func() { got.ToSML() })
+}

--- a/sml/README.md
+++ b/sml/README.md
@@ -60,8 +60,7 @@ functions (which each allocate a fresh parser).
 
 ### Quick start
 
-`Encode` renders a `secs2.Item` to its canonical SML text, identical to
-`item.ToSML()`:
+`Encode` renders a valid `secs2.Item` to its canonical SML text, identical to `item.ToSML()`:
 
 ```go
 text := sml.Encode(item)
@@ -73,14 +72,19 @@ text := sml.Encode(item)
 text := sml.EncodeStrict(item)
 ```
 
-`EncodeMessage` renders a full `*hsms.DataMessage` (header line + body); `MustEncodeMessage` is the
-same but returns a `"<!sml encode error: ...>"` diagnostic string instead of an error, safe to embed
-directly in a log line:
+`EncodeMessage` renders a full `*hsms.DataMessage` (header line + body).
+`MustEncodeMessage` is the same but returns a `"<!sml encode error: ...>"` diagnostic string instead of an error,
+so it is safe to embed directly in a log line:
 
 ```go
 text, err := sml.EncodeMessage(msg)
 logLine := sml.MustEncodeMessage(msg) // never panics
 ```
+
+Item encoding returns empty text for a nil-like item.
+For a programmatic item tree deeper than `secs2.MaxListDepth`, item encoding returns a `"<!sml encode error: ...>"` diagnostic,
+while message encoding returns an error.
+`MustEncodeMessage` returns the diagnostic form for message errors and never panics.
 
 ### Custom encoder
 
@@ -104,8 +108,8 @@ dst = enc.AppendEncode(dst, item)
 text, err := enc.EncodeMessage(msg)
 ```
 
-The default `NewEncoder()` (no options) produces the same output as
-`item.ToSML()`, with an unquoted S/F header (e.g. `S1F1 W`).
+For a valid item tree at or below `secs2.MaxListDepth`, the default `NewEncoder()` produces the same output as `item.ToSML()`.
+Message encoding uses an unquoted S/F header by default (e.g. `S1F1 W`).
 
 ### Encoder options
 

--- a/sml/doc.go
+++ b/sml/doc.go
@@ -22,7 +22,9 @@
 //
 // # Encoding
 //
-// [Encode] renders a secs2.Item to its canonical SML text — identical to item.ToSML().
+// [Encode] renders a valid secs2.Item tree at or below [secs2.MaxListDepth] to canonical SML text identical to item.ToSML().
+// Nil-like items render as empty text.
+// Deeper trees produce a diagnostic from item encoding and an error from message encoding.
 // [NewEncoder] provides a configurable form:
 //
 //	enc := sml.NewEncoder(

--- a/sml/encoder.go
+++ b/sml/encoder.go
@@ -2,6 +2,7 @@ package sml
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -11,7 +12,9 @@ import (
 
 // Encoder renders secs2 Items / hsms messages to SML text.
 //
-// Its zero-value defaults (set in NewEncoder) reproduce secs2.Item.ToSML() byte-for-byte.
+// NewEncoder's default options reproduce secs2.Item.ToSML() byte-for-byte for valid item trees at or below [secs2.MaxListDepth].
+// Nil-like items render as empty text.
+// Deeper trees produce a diagnostic from item encoding and an error from message encoding.
 // An Encoder is immutable after construction and safe for concurrent use.
 type Encoder struct {
 	strict      bool
@@ -21,8 +24,9 @@ type Encoder struct {
 	indent      string
 }
 
-// NewEncoder returns an Encoder; with no options Encode(item) equals item.ToSML(),
-// and EncodeMessage uses an UNQUOTED canonical S/F header (e.g. "S1F1 W").
+// NewEncoder returns an Encoder.
+// With no options, Encode(item) equals item.ToSML() for valid item trees at or below [secs2.MaxListDepth].
+// EncodeMessage uses an UNQUOTED canonical S/F header (e.g. "S1F1 W").
 func NewEncoder(opts ...EncoderOption) *Encoder {
 	e := &Encoder{asciiQuote: QuoteDouble, sfQuote: QuoteNone, binaryStyle: BinaryHex, indent: "  "}
 	for _, opt := range opts {
@@ -31,14 +35,29 @@ func NewEncoder(opts ...EncoderOption) *Encoder {
 	return e
 }
 
-// Encode renders item to SML text.
+// Encode renders item to SML text using the Encoder's configured options.
+// It returns empty text for a nil-like item.
+// For an item tree deeper than [secs2.MaxListDepth], it returns a diagnostic of the form "<!sml encode error: ...>".
 func (e *Encoder) Encode(it secs2.Item) string {
+	s, err := e.encodeChecked(it)
+	if err != nil {
+		return fmt.Sprintf("<!sml encode error: %v>", err)
+	}
+
+	return s
+}
+
+func (e *Encoder) encodeChecked(it secs2.Item) (string, error) {
 	var sb strings.Builder
-	e.encodeItem(&sb, it, 0)
-	return sb.String()
+	if err := e.encodeItem(&sb, it, 0); err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
 }
 
 // AppendEncode appends item's SML text to dst.
+// It appends nothing for a nil-like item and appends the Encode diagnostic for a tree deeper than [secs2.MaxListDepth].
 func (e *Encoder) AppendEncode(dst []byte, it secs2.Item) []byte {
 	return append(dst, e.Encode(it)...)
 }
@@ -50,12 +69,20 @@ func (e *Encoder) quoteByte() byte {
 	return '"'
 }
 
-func (e *Encoder) encodeItem(sb *strings.Builder, it secs2.Item, level int) {
+func (e *Encoder) encodeItem(sb *strings.Builder, it secs2.Item, level int) error {
+	if isNilItem(it) {
+		return nil
+	}
+
 	switch {
 	case it.IsEmpty():
 		// EmptyItem.ToSML() == ""
 	case it.IsList():
-		e.encodeList(sb, it, level)
+		if level >= secs2.MaxListDepth {
+			return fmt.Errorf("sml: list nesting depth exceeds maximum allowed: %d", secs2.MaxListDepth)
+		}
+
+		return e.encodeList(sb, it, level)
 	case it.IsASCII():
 		s, _ := it.ToASCII()
 		e.encodeString(sb, "A", s, e.strict) // ASCII honors strict (0xHH tokens)
@@ -80,6 +107,8 @@ func (e *Encoder) encodeItem(sb *strings.Builder, it secs2.Item, level int) {
 	default:
 		// unknown item type: no output
 	}
+
+	return nil
 }
 
 // encodeString renders an ASCII/JIS8 string. strict==true (ASCII only) emits
@@ -191,12 +220,13 @@ func (e *Encoder) encodeFloat(sb *strings.Builder, it secs2.Item) {
 	sb.WriteByte('>')
 }
 
-func (e *Encoder) encodeList(sb *strings.Builder, it secs2.Item, level int) {
+func (e *Encoder) encodeList(sb *strings.Builder, it secs2.Item, level int) error {
 	ind := strings.Repeat(e.indent, level)
 	if it.Size() == 0 {
 		sb.WriteString(ind)
 		sb.WriteString("<L[0]>")
-		return
+
+		return nil
 	}
 	sb.WriteString(ind)
 	sb.WriteString("<L[")
@@ -204,16 +234,22 @@ func (e *Encoder) encodeList(sb *strings.Builder, it secs2.Item, level int) {
 	sb.WriteString("]\n")
 	child := strings.Repeat(e.indent, level+1)
 	for c := range it.Items() {
-		if c.IsList() {
-			e.encodeItem(sb, c, level+1)
+		if !isNilItem(c) && c.IsList() {
+			if err := e.encodeItem(sb, c, level+1); err != nil {
+				return err
+			}
 		} else {
 			sb.WriteString(child)
-			e.encodeItem(sb, c, level+1)
+			if err := e.encodeItem(sb, c, level+1); err != nil {
+				return err
+			}
 		}
 		sb.WriteByte('\n')
 	}
 	sb.WriteString(ind)
 	sb.WriteByte('>')
+
+	return nil
 }
 
 // EncodeMessage renders the message header line then its body.
@@ -221,7 +257,12 @@ func (e *Encoder) encodeList(sb *strings.Builder, it secs2.Item, level int) {
 // The body is obtained via msg.Item(), which for a decoded (raw-frame) message decodes lazily and may return an error —
 // propagated, not swallowed.
 // A message with an empty body renders as just the header line followed by the terminating ".".
+// A nil message or a body tree deeper than [secs2.MaxListDepth] returns an error.
 func (e *Encoder) EncodeMessage(msg *hsms.DataMessage) (string, error) {
+	if msg == nil {
+		return "", fmt.Errorf("sml: nil data message")
+	}
+
 	item, err := msg.Item()
 	if err != nil {
 		return "", fmt.Errorf("sml: encode message body: %w", err) // wrap lazy-decode error, per spec §7
@@ -229,7 +270,9 @@ func (e *Encoder) EncodeMessage(msg *hsms.DataMessage) (string, error) {
 	var sb strings.Builder
 	e.writeHeader(&sb, msg)
 	sb.WriteByte('\n')
-	e.encodeItem(&sb, item, 0)
+	if err := e.encodeItem(&sb, item, 0); err != nil {
+		return "", fmt.Errorf("sml: encode message body: %w", err)
+	}
 	sb.WriteString("\n.")
 
 	return sb.String(), nil
@@ -259,18 +302,23 @@ func (e *Encoder) writeSFQuote(sb *strings.Builder) {
 }
 
 // Encode renders item to SML text using default (non-strict, canonical) options.
+// For a valid item tree at or below [secs2.MaxListDepth], the output equals item.ToSML() byte-for-byte.
+// It returns empty text for a nil-like item and an "<!sml encode error: ...>" diagnostic for a deeper tree.
 func Encode(it secs2.Item) string { return NewEncoder().Encode(it) }
 
 // EncodeStrict renders item with strict (round-trippable) ASCII escaping.
+// It returns empty text for a nil-like item
+// and an "<!sml encode error: ...>" diagnostic for a tree deeper than [secs2.MaxListDepth].
 func EncodeStrict(it secs2.Item) string {
 	return NewEncoder(WithEncoderStrictMode(true)).Encode(it)
 }
 
-// EncodeMessage renders msg to SML text using an encoder configured by opts (default:
-// hex binary, double-quoted ASCII, unquoted S/F header).
+// EncodeMessage renders msg to SML text using an encoder configured by opts.
+// The defaults are hex binary, double-quoted ASCII, and an unquoted S/F header.
 //
 // It mirrors the item-level Encode shortcut.
 // The body is decoded lazily via msg.Item(); a decode error is returned, not swallowed.
+// A nil message or a body tree deeper than [secs2.MaxListDepth] returns an error.
 func EncodeMessage(msg *hsms.DataMessage, opts ...EncoderOption) (string, error) {
 	return NewEncoder(opts...).EncodeMessage(msg)
 }
@@ -288,6 +336,17 @@ func MustEncodeMessage(msg *hsms.DataMessage, opts ...EncoderOption) string {
 	}
 
 	return s
+}
+
+func isNilItem(it secs2.Item) bool {
+	if it == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(it)
+	k := v.Kind()
+
+	return (k == reflect.Chan || k == reflect.Func || k == reflect.Map || k == reflect.Pointer || k == reflect.Slice) && v.IsNil()
 }
 
 // writeStrictASCII renders s as printable runs quoted with `quote` and
@@ -322,7 +381,7 @@ func writeStrictASCII(sb *strings.Builder, s string, quote byte) {
 				sb.WriteByte(quote)
 				inRun = true
 			}
-			if c == quote || c == '\\' {
+			if c == quote || c == '\\' || c == '>' {
 				sb.WriteByte('\\')
 			}
 			sb.WriteByte(c)

--- a/sml/encoder_test.go
+++ b/sml/encoder_test.go
@@ -2,12 +2,28 @@ package sml
 
 import (
 	"encoding/binary"
+	"iter"
+	"strings"
 	"testing"
 
 	"github.com/arloliu/go-secs/v2/hsms"
 	"github.com/arloliu/go-secs/v2/secs2"
 	"github.com/stretchr/testify/require"
 )
+
+type cyclicListItem struct {
+	secs2.Item
+}
+
+func (item *cyclicListItem) IsList() bool { return true }
+
+func (item *cyclicListItem) Size() int { return 1 }
+
+func (item *cyclicListItem) Items() iter.Seq[secs2.Item] {
+	return func(yield func(secs2.Item) bool) {
+		yield(item)
+	}
+}
 
 func TestEncoder_DefaultEqualsToSML(t *testing.T) {
 	items := []secs2.Item{
@@ -78,6 +94,40 @@ func TestEncode_PackageShortcut(t *testing.T) {
 	}
 }
 
+func TestEncode_NilItemIsEmpty(t *testing.T) {
+	require.Empty(t, Encode(nil))
+	require.Empty(t, EncodeStrict(nil))
+	require.Equal(t, "prefix", string(NewEncoder().AppendEncode([]byte("prefix"), nil)))
+
+	var typedNil *secs2.ASCIIItem
+	require.Empty(t, Encode(typedNil))
+	require.Empty(t, EncodeStrict(typedNil))
+	require.Equal(t, "prefix", string(NewEncoder().AppendEncode([]byte("prefix"), typedNil)))
+}
+
+func TestEncode_ListDepthBound(t *testing.T) {
+	item := secs2.A("leaf")
+	for range secs2.MaxListDepth {
+		item = secs2.NewListItem(item)
+	}
+
+	require.NotContains(t, Encode(item), "<!sml encode error:")
+
+	item = secs2.NewListItem(item)
+	require.Contains(t, Encode(item), "<!sml encode error:")
+
+	msg, err := hsms.NewDataMessage(1, 1, false, 0, [4]byte{}, item)
+	require.NoError(t, err)
+	out, err := EncodeMessage(msg)
+	require.ErrorContains(t, err, "list nesting depth exceeds maximum allowed")
+	require.Empty(t, out)
+}
+
+func TestEncode_CyclicListIsBounded(t *testing.T) {
+	item := &cyclicListItem{Item: secs2.A("leaf")}
+	require.Contains(t, Encode(item), "<!sml encode error:")
+}
+
 // TestEncodeStrict_PackageShortcut verifies EncodeStrict(item):
 //   - for items with no non-printable bytes, is identical to the non-strict Encode(item)
 //     and to item.ToSML();
@@ -111,6 +161,30 @@ func TestEncodeStrict_PackageShortcut(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "a\nb", gotStr)
 	})
+}
+
+func TestEncodeStrict_GreaterThanRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		quote QuoteStyle
+	}{
+		{name: "double quote", quote: QuoteDouble},
+		{name: "single quote", quote: QuoteSingle},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enc := NewEncoder(WithEncoderStrictMode(true), WithASCIIQuote(tt.quote))
+			item := secs2.A(`a>b\c'"d`)
+			out := enc.Encode(item)
+			require.Contains(t, out, `\>`)
+
+			msgs, err := NewParser(WithParserStrictMode(true)).Parse("S1F1 " + out + ".")
+			require.NoError(t, err)
+			got, err := msgs[0].Item()
+			require.NoError(t, err)
+			require.True(t, secs2.Equal(item, got))
+		})
+	}
 }
 
 // TestAppendEncode verifies (*Encoder).AppendEncode appends the item's encoded SML text
@@ -156,6 +230,32 @@ func TestEncodeMessage_PackageShortcut(t *testing.T) {
 	got, err = EncodeMessage(msg, WithSFQuote(QuoteSingle))
 	require.NoError(t, err)
 	require.Equal(t, "'S1F1'\n<A[2] \"hi\">\n.", got)
+}
+
+func TestEncodeMessage_DoesNotAllocateIntermediateBody(t *testing.T) {
+	item := secs2.A(strings.Repeat("x", 4096))
+	msg, err := hsms.NewDataMessage(1, 1, false, 0, [4]byte{}, item)
+	require.NoError(t, err)
+	enc := NewEncoder()
+
+	var encoded string
+	itemAllocs := testing.AllocsPerRun(100, func() {
+		encoded = enc.Encode(item)
+	})
+
+	var encodeErr error
+	messageAllocs := testing.AllocsPerRun(100, func() {
+		encoded, encodeErr = enc.EncodeMessage(msg)
+	})
+	require.NoError(t, encodeErr)
+	require.NotEmpty(t, encoded)
+	require.LessOrEqual(t, messageAllocs, itemAllocs+1)
+}
+
+func TestEncodeMessage_Nil(t *testing.T) {
+	_, err := EncodeMessage(nil)
+	require.ErrorContains(t, err, "nil data message")
+	require.Contains(t, MustEncodeMessage(nil), "<!sml encode error:")
 }
 
 // TestEncodeMessage_DecodeErrorPropagates verifies that EncodeMessage returns the lazy body-decode

--- a/sml/parser.go
+++ b/sml/parser.go
@@ -14,6 +14,8 @@ import (
 
 const eof rune = -1
 
+const smlPreallocCap = 64
+
 // Parser is a parser for HSMS data messages in SML (SECS Message Language) format.
 //
 // It provides methods for parsing SML strings to HSMS data messages.
@@ -200,18 +202,20 @@ func (p *Parser) parseHSMSHeader() error {
 		return p.errf("invalid SML message without dot symbol or newline")
 	}
 
-	// try to find if the first item bracket '<' is present in the data, and choose the maximum index
-	// of the firstTerm and firstItemBracket.
-	//
-	// if firstTerm is not found or < firstItemBracket, we needs to use the firstItemBracket index
-	// as the end of search range for searching the message name.
-	//
-	// if firstItemBracket is not found or < firstTerm, we needs to use the firstTerm index
-	// as the end of search range for searching the message name.
 	firstItemBracket := strings.IndexByte(p.data, byte('<'))
-	i := max(firstTerm, firstItemBracket)
-	if i < 0 {
-		return p.errf("invalid SML message without item bracket '<' and dot symbol")
+	if firstItemBracket >= 0 {
+		nameSeparator := strings.IndexByte(p.data[:firstItemBracket], byte(':'))
+		if nameSeparator > firstTerm {
+			nextTerm := strings.IndexAny(p.data[nameSeparator+1:], "\n.")
+			if nextTerm < 0 {
+				return p.errf("invalid SML message without dot symbol or newline")
+			}
+			firstTerm = nameSeparator + 1 + nextTerm
+		}
+	}
+	i := firstTerm
+	if firstItemBracket >= 0 && firstItemBracket < i {
+		i = firstItemBracket
 	}
 
 	// get optional message name
@@ -1095,17 +1099,14 @@ func (p *Parser) nextItemSize() (int, error) {
 	return 0, p.errf("invalid item size")
 }
 
-// capHint bounds a preallocation hint against the bytes actually left to parse.
+// capHint bounds an attacker-controlled preallocation hint against the bytes actually left to parse.
 //
 // size comes straight off the SML declared-count token (`[n]` or `[n..m]`).
-// It is attacker-controlled and bounded only by math.MaxInt32, never by the input actually present.
-// Uncapped, it lets `<U1[2000000000] 1 2 3>` demand gigabytes before any payload byte is read.
-//
 // remaining is len(p.data) at the call site.
-// Every element still to be produced consumes at least one input byte, so it bounds what may follow.
-// Counts matching the remaining input are unaffected; the buffer still grows past the hint.
+// The fixed ceiling prevents unrelated trailing input from amplifying the initial allocation.
+// It does not limit valid item sizes because slices and strings.Builder continue growing as values are parsed.
 func capHint(size, remaining int) int {
-	return min(size, remaining)
+	return min(size, remaining, smlPreallocCap)
 }
 
 func toUpperRune(ch rune) rune {

--- a/sml/parser_dos_test.go
+++ b/sml/parser_dos_test.go
@@ -94,6 +94,36 @@ func TestParse_HugeDeclaredSizeDoesNotPrealloc(t *testing.T) {
 	}
 }
 
+func TestParse_PaddingDoesNotAmplifyPreallocation(t *testing.T) {
+	padding := strings.Repeat("/*padding*/", 200_000)
+	strictASCIIPadding := strings.Repeat("/*padding*/", 1_000_000)
+	tests := []struct {
+		name   string
+		input  string
+		strict bool
+	}{
+		{name: "list", input: `S1F1 <L[100000000] <A "x">>.` + padding},
+		{name: "uint", input: `S1F1 <U1[100000000] 1>.` + padding},
+		{name: "ascii_strict", input: `S1F1 <A[100000000] "x">.` + strictASCIIPadding, strict: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewParser()
+			if tt.strict {
+				parser = NewParser(WithParserStrictMode(true))
+			}
+
+			runtime.GC() //nolint:revive // a collected heap is what makes the TotalAlloc delta below meaningful
+			var before, after runtime.MemStats
+			runtime.ReadMemStats(&before)
+			_, _ = parser.Parse(tt.input) //nolint:errcheck // allocation is the only thing under test
+			runtime.ReadMemStats(&after)
+			require.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(maxAllowedAllocBytes))
+		})
+	}
+}
+
 // TestParseStrict_LongNumericTokenDoesNotCopyQuadratically guards the unquoted numeric token.
 // The token used to be accumulated one rune at a time into a string.
 // Go strings are immutable, so that cost O(n^2) copying before the token was even validated.

--- a/sml/parser_test.go
+++ b/sml/parser_test.go
@@ -213,6 +213,40 @@ func TestParse_NoErrorCases_NonStrictMode(t *testing.T) {
 	checkTestCase(t, tests, false)
 }
 
+func TestParse_ItemColonDoesNotNameHeader(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "scalar item", input: `S1F1 <A "x:y">.`, want: "x:y"},
+		{name: "nested item", input: `S1F1 <L[1] <A "x:y">>.`, want: "x:y"},
+		{name: "named header", input: `Message: S1F1 <A "x:y">.`, want: "x:y"},
+		{name: "URL with port", input: `Message: S1F1 <A "http://example.com:8080/path">.`, want: "http://example.com:8080/path"},
+		{name: "body on next line", input: "Message: S1F1\n<A \"x:y\">.", want: "x:y"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgs, err := Parse(tt.input)
+			require.NoError(t, err)
+			require.Len(t, msgs, 1)
+			require.Equal(t, uint8(1), msgs[0].Stream())
+			require.Equal(t, uint8(1), msgs[0].Function())
+
+			item, err := msgs[0].Item()
+			require.NoError(t, err)
+			if item.IsList() {
+				item, err = item.ItemAt(0)
+				require.NoError(t, err)
+			}
+			ascii, err := item.ToASCII()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, ascii)
+		})
+	}
+}
+
 func TestParseItem_ASCII(t *testing.T) {
 	testcases := []struct {
 		description    string


### PR DESCRIPTION
## Why

A QA pass over the public surface found a family of inputs that panicked
instead of returning an error, two SML output/parse defects, and a SECS-I
failure classification that reported dropped sockets as protocol timer
expiries. This branch closes them and cuts v2.4.1.

## What changed

**Nil-like input no longer panics.** Public constructors, options, cursor
traversal, list traversal, send and reply helpers, and the SML logging helpers
now return an error or a diagnostic where they previously dereferenced a nil
interface or nil pointer. This covers `hsms`, `hsmsss`, `secs1`, `secs2`,
`sml`, and the `hsmstest` fake, which is guarded to match the real session so
consumer test suites see the same contract.

**SML hardening.** Programmatic item trees stop at the same nesting depth the
parser and wire decoder already enforce, and padded trailing input no longer
amplifies parser preallocation. Strict output escapes `>`, and a single-line
item's colon no longer alters header parsing.

**SECS-II list integrity.** An invalid list no longer emits a child count that
disagrees with its wire payload.

**SECS-I failure classification.** EOF and socket failures report as I/O errors
rather than `ErrT1Timeout` / `ErrT2Timeout`, and a read error during a
contention yield aborts rather than retrying a dead line to exhaustion. The
sentinels were already documented as actual timer expiries; this aligns
identity with that contract. **This is the one migration-visible change** —
consumers branching on `errors.Is(err, secs1.ErrT2Timeout)` for a dropped peer
will take a different branch, with no compile error to flag it.

**HSMS-SS tracing.** Inbound control tracing follows live logger and trace
updates instead of a stale snapshot.

## Version

`gorelease -base=v2.4.0` suggests **v2.4.1**. No exported signature, interface
method set, struct field, or const block entry changed. Every new error return
replaces a panic, not a success.

## Verification

- `make lint` — 0 issues
- `make test` — 14/14 packages
- `make stress-test` — green locally, all packages, both GOMAXPROCS modes,
  10 iterations each (CI does not run it)
- `gorelease -base=v2.4.0` — v2.4.1

Reviewed by two external models against a shared brief with the accepted
residuals declared out of scope; both returned patch-safe / ship. Their reports
and a consolidated summary are in `tmp/` (untracked).

## Test-harness race fixed here

CI initially failed `TestParity_InvoluntaryDropReconnects/secs1` with
"connection did not tear down after the involuntary drop". That is a
pre-existing flake in the integration harness, not a regression:

`awaitState` snapshotted the edge count on entry, so it only saw transitions
recorded after the call began. The notifier records on its own goroutine and a
secs1 teardown lands within one poll tick (10ms), so a test goroutine
descheduled between `dropLine()` and the wait would find the edge already
recorded, skip past it, and time out on a transition that had already happened.
The 3s budget is irrelevant — the edge is missed, not late.

Reproduced deterministically on **v2.4.0** by injecting an 80ms deschedule after
`dropLine()`: fails every run, on both transports, with the identical message.
CI hit only `/secs1` because its 10ms poll makes teardown fastest, so it needs
the smallest deschedule to lose the race.

Fixed by replacing `awaitState` with `mark()` + `awaitStateFrom()`, taking the
scan origin before the triggering action. Sequential waits resume at the
previous match's index + 1, so a follow-up wait cannot be satisfied by an edge
recorded before the trigger — otherwise the re-Select wait would match the
initial Selected and pass without any reconnect.

Verified both ways: with the 80ms deschedule injected it now passes 10/10, and
refusing every redial still fails the re-Select assertion, so the guard keeps
its teeth.

## Deferred

`ToSML()` has no depth ceiling while the `sml` encoder now does — tracked in
 #11. Adding the ceiling would turn a 65-deep tree from correct SML into an
empty string, a behavior change on valid input that does not belong in a patch.

Known follow-ups accepted for this release are recorded in the CHANGELOG.
